### PR TITLE
Fix Next.js 15 async searchParams and client/server boundary issues

### DIFF
--- a/mcp-server/app/logs/LogsClient.test.ts
+++ b/mcp-server/app/logs/LogsClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseLogEntries } from './LogsClient';
+import { parseLogEntries } from './utils';
 import { LogEntry } from '../../types';
 
 describe('parseLogEntries', () => {

--- a/mcp-server/app/logs/LogsClient.tsx
+++ b/mcp-server/app/logs/LogsClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { LogEntry, LogsApiResponse, ConfigApiResponse, LogFile, LogListResponse } from '@/types';
+import { parseLogEntries } from './utils';
 
 // Hook for dark mode with system preference detection
 function useDarkMode() {
@@ -49,50 +50,6 @@ function useDarkMode() {
   return [darkMode, setDarkMode] as const;
 }
 
-export function parseLogEntries(logContent: string): LogEntry[] {
-  // Split by timestamp pattern - each timestamp starts a new log entry
-  const timestampPattern = /\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\] \[([^\]]+)\] /;
-  
-  const entries: LogEntry[] = [];
-  const lines = logContent.split('\n');
-  let currentEntry: LogEntry | null = null;
-  
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    
-    const match = line.match(timestampPattern);
-    if (match) {
-      // Save previous entry if exists
-      if (currentEntry) {
-        entries.push(currentEntry);
-      }
-      
-      // Start new entry
-      const [fullMatch, timestamp, source] = match;
-      const message = line.substring(fullMatch.length);
-      const screenshot = message.match(/\[SCREENSHOT\] (.+)/)?.[1];
-      
-      currentEntry = {
-        timestamp,
-        source,
-        message,
-        screenshot,
-        original: line
-      };
-    } else if (currentEntry) {
-      // Append to current entry's message
-      currentEntry.message += '\n' + line;
-      currentEntry.original += '\n' + line;
-    }
-  }
-  
-  // Don't forget the last entry
-  if (currentEntry) {
-    entries.push(currentEntry);
-  }
-  
-  return entries;
-}
 
 // Keep this for backwards compatibility, but it's not used anymore
 function parseLogLine(line: string): LogEntry | null {

--- a/mcp-server/app/logs/page.tsx
+++ b/mcp-server/app/logs/page.tsx
@@ -1,10 +1,11 @@
-import LogsClient, { parseLogEntries } from './LogsClient';
+import LogsClient from './LogsClient';
 import { redirect } from 'next/navigation';
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, dirname, basename } from 'path';
+import { parseLogEntries } from './utils';
 
 interface PageProps {
-  searchParams: { file?: string; mode?: 'head' | 'tail' };
+  searchParams: Promise<{ file?: string; mode?: 'head' | 'tail' }>;
 }
 
 async function getLogFiles() {
@@ -81,17 +82,20 @@ async function getLogData(logPath: string, mode: 'head' | 'tail' = 'tail', lines
 export default async function LogsPage({ searchParams }: PageProps) {
   const version = process.env.DEV3000_VERSION || '0.0.0';
   
+  // Await searchParams (Next.js 15 requirement)
+  const params = await searchParams;
+  
   // Get available log files
   const { files, currentFile } = await getLogFiles();
   
   // If no file specified and we have files, redirect to latest
-  if (!searchParams.file && files.length > 0) {
+  if (!params.file && files.length > 0) {
     const latestFile = files[0].name;
     redirect(`/logs?file=${encodeURIComponent(latestFile)}`);
   }
   
   // If no file specified and no files available, render with empty data
-  if (!searchParams.file) {
+  if (!params.file) {
     return (
       <LogsClient 
         version={version}
@@ -106,9 +110,9 @@ export default async function LogsPage({ searchParams }: PageProps) {
   }
   
   // Find the selected log file
-  const selectedFile = files.find(f => f.name === searchParams.file);
+  const selectedFile = files.find(f => f.name === params.file);
   const logPath = selectedFile?.path || currentFile;
-  const mode = (searchParams.mode as 'head' | 'tail') || 'tail';
+  const mode = (params.mode as 'head' | 'tail') || 'tail';
   
   // Get initial log data server-side
   const logData = await getLogData(logPath, mode);

--- a/mcp-server/app/logs/utils.ts
+++ b/mcp-server/app/logs/utils.ts
@@ -1,0 +1,46 @@
+import { LogEntry } from '@/types';
+
+export function parseLogEntries(logContent: string): LogEntry[] {
+  // Split by timestamp pattern - each timestamp starts a new log entry
+  const timestampPattern = /\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\] \[([^\]]+)\] /;
+  
+  const entries: LogEntry[] = [];
+  const lines = logContent.split('\n');
+  let currentEntry: LogEntry | null = null;
+  
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    
+    const match = line.match(timestampPattern);
+    if (match) {
+      // Save previous entry if exists
+      if (currentEntry) {
+        entries.push(currentEntry);
+      }
+      
+      // Start new entry
+      const [fullMatch, timestamp, source] = match;
+      const message = line.substring(fullMatch.length);
+      const screenshot = message.match(/\[SCREENSHOT\] (.+)/)?.[1];
+      
+      currentEntry = {
+        timestamp,
+        source,
+        message,
+        screenshot,
+        original: line
+      };
+    } else if (currentEntry) {
+      // Append to current entry's message
+      currentEntry.message += '\n' + line;
+      currentEntry.original += '\n' + line;
+    }
+  }
+  
+  // Don't forget the last entry
+  if (currentEntry) {
+    entries.push(currentEntry);
+  }
+  
+  return entries;
+}


### PR DESCRIPTION
## Summary
- Fixed Next.js 15 requirement to await searchParams before accessing its properties
- Resolved client/server module boundary error with parseLogEntries function
- Eliminated code duplication by creating a shared utility file

## Problem
The log viewer was throwing errors after upgrading to Next.js 15:
1. `searchParams should be awaited before using its properties` - Next.js 15 now requires searchParams to be awaited as it's a Promise
2. `Attempted to call parseLogEntries() from the server but parseLogEntries is on the client` - Function exported from a 'use client' file cannot be called from server components

## Solution
- Made `searchParams` async and properly await it in `page.tsx`
- Moved `parseLogEntries` to a new shared `utils.ts` file (without 'use client' directive) that both client and server components can import
- Updated tests to import from the new location

## Test Plan
- [x] Tests pass successfully
- [x] Log viewer loads without errors
- [x] No duplicate parsing of log entries
- [x] TypeScript compilation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)