### PR TITLE
Extract parseLogEntries to shared utils file

### DIFF
--- a/mcp-server/app/logs/LogsClient.test.ts
+++ b/mcp-server/app/logs/LogsClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseLogEntries } from './LogsClient';
+import { parseLogEntries } from './utils';
 import { LogEntry } from '../../types';
 
 describe('parseLogEntries', () => {

--- a/mcp-server/app/logs/LogsClient.tsx
+++ b/mcp-server/app/logs/LogsClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { LogEntry, LogsApiResponse, ConfigApiResponse, LogFile, LogListResponse } from '@/types';
+import { parseLogEntries } from './utils';
 
 // Hook for dark mode with system preference detection
 function useDarkMode() {
@@ -47,51 +48,6 @@ function useDarkMode() {
   }, []);
 
   return [darkMode, setDarkMode] as const;
-}
-
-export function parseLogEntries(logContent: string): LogEntry[] {
-  // Split by timestamp pattern - each timestamp starts a new log entry
-  const timestampPattern = /\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\] \[([^\]]+)\] /;
-  
-  const entries: LogEntry[] = [];
-  const lines = logContent.split('\n');
-  let currentEntry: LogEntry | null = null;
-  
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    
-    const match = line.match(timestampPattern);
-    if (match) {
-      // Save previous entry if exists
-      if (currentEntry) {
-        entries.push(currentEntry);
-      }
-      
-      // Start new entry
-      const [fullMatch, timestamp, source] = match;
-      const message = line.substring(fullMatch.length);
-      const screenshot = message.match(/\[SCREENSHOT\] (.+)/)?.[1];
-      
-      currentEntry = {
-        timestamp,
-        source,
-        message,
-        screenshot,
-        original: line
-      };
-    } else if (currentEntry) {
-      // Append to current entry's message
-      currentEntry.message += '\n' + line;
-      currentEntry.original += '\n' + line;
-    }
-  }
-  
-  // Don't forget the last entry
-  if (currentEntry) {
-    entries.push(currentEntry);
-  }
-  
-  return entries;
 }
 
 // Keep this for backwards compatibility, but it's not used anymore

--- a/mcp-server/app/logs/page.tsx
+++ b/mcp-server/app/logs/page.tsx
@@ -1,7 +1,8 @@
-import LogsClient, { parseLogEntries } from './LogsClient';
+import LogsClient from './LogsClient';
 import { redirect } from 'next/navigation';
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, dirname, basename } from 'path';
+import { parseLogEntries } from './utils';
 
 interface PageProps {
   searchParams: { file?: string; mode?: 'head' | 'tail' };

--- a/mcp-server/app/logs/utils.ts
+++ b/mcp-server/app/logs/utils.ts
@@ -1,0 +1,46 @@
+import { LogEntry } from '@/types';
+
+export function parseLogEntries(logContent: string): LogEntry[] {
+  // Split by timestamp pattern - each timestamp starts a new log entry
+  const timestampPattern = /\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\] \[([^\]]+)\] /;
+  
+  const entries: LogEntry[] = [];
+  const lines = logContent.split('\n');
+  let currentEntry: LogEntry | null = null;
+  
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    
+    const match = line.match(timestampPattern);
+    if (match) {
+      // Save previous entry if exists
+      if (currentEntry) {
+        entries.push(currentEntry);
+      }
+      
+      // Start new entry
+      const [fullMatch, timestamp, source] = match;
+      const message = line.substring(fullMatch.length);
+      const screenshot = message.match(/\[SCREENSHOT\] (.+)/)?.[1];
+      
+      currentEntry = {
+        timestamp,
+        source,
+        message,
+        screenshot,
+        original: line
+      };
+    } else if (currentEntry) {
+      // Append to current entry's message
+      currentEntry.message += '\n' + line;
+      currentEntry.original += '\n' + line;
+    }
+  }
+  
+  // Don't forget the last entry
+  if (currentEntry) {
+    entries.push(currentEntry);
+  }
+  
+  return entries;
+}


### PR DESCRIPTION
## Bug:

When accessing the logs UI (e.g. http://localhost:3684/logs?file=dev3000-my-app-2025-09-07T16-37-27-702Z.log), the following error occurs:

```
Attempted to call parseLogEntries() from the server but parseLogEntries is on the client. 
It's not possible to invoke a client function from the server, it can only be rendered as a 
Component or passed to props of a Client Component.

Call Stack
6

LogsPage
about:/Server/file:///Users/david/dev/open%20source/dev3000/mcp-server/.next/server/chunks/ssr/%5Broot-of-the-server%5D__2c3bb7f4._.js (177:170)
resolveErrorDev
file:///Users/david/dev/open%20source/dev3000/mcp-server/.next/static/chunks/node_modules_next_dist_compiled_5150ccfd._.js (4265:48)
processFullStringRow
file:///Users/david/dev/open%20source/dev3000/mcp-server/.next/static/chunks/node_modules_next_dist_compiled_5150ccfd._.js (4513:29)
processFullBinaryRow
file:///Users/david/dev/open%20source/dev3000/mcp-server/.next/static/chunks/node_modules_next_dist_compiled_5150ccfd._.js (4472:9)
processBinaryChunk
file:///Users/david/dev/open%20source/dev3000/mcp-server/.next/static/chunks/node_modules_next_dist_compiled_5150ccfd._.js (4581:98)
progress
file:///Users/david/dev/open%20source/dev3000/mcp-server/.next/static/chunks/node_modules_next_dist_compiled_5150ccfd._.js (4747:25)
```

## Fix:

Move `parseLogEntries` function from `LogsClient.tsx` (client component) to a shared `utils.ts` file to fix client/server module boundary error. This allows both server and client components to import the function without issues.