### PR TITLE
Increased security by reducing the number of masked characters in the authorization header

### DIFF
--- a/src/cdp-monitor.ts
+++ b/src/cdp-monitor.ts
@@ -546,7 +546,10 @@ export class CDPMonitor {
       const importantHeaders = ["content-type", "authorization", "cookie"]
       const headerInfo = importantHeaders
         .filter((h) => headers?.[h])
-        .map((h) => `${h}: ${headers?.[h]?.slice(0, 50) || ""}${(headers?.[h]?.length || 0) > 50 ? "..." : ""}`)
+        .map((h) => {
+          const maxLength = h === 'authorization' ? 10 : 50;
+          return `${h}: ${headers?.[h]?.slice(0, maxLength) || ""}${(headers?.[h]?.length || 0) > maxLength ? "..." : ""}`;
+        })
         .join(", ")
 
       if (headerInfo) logMsg += ` [${headerInfo}]`


### PR DESCRIPTION
Currently, the HTTP log displays the first 50 characters of the authorization header value, which may expose API key completely.

- Changed authorization header display limit from 50 to 10 characters
- Prevents full API key exposure in logs while maintaining debuggability
- Cookie and content-type headers remain at 50 char limit

