### PR TITLE
feat: read for uppercase G in TUI shortcut

### DIFF
--- a/src/tui-interface-impl.tsx
+++ b/src/tui-interface-impl.tsx
@@ -260,10 +260,10 @@ const TUIApp = ({
       setScrollOffset((prev) => Math.min(prev + maxVisibleLogs, Math.max(0, filteredCount - maxVisibleLogs)))
     } else if (key.pageDown) {
       setScrollOffset((prev) => Math.max(0, prev - maxVisibleLogs))
-    } else if (input === "G") {
+    } else if (input === "G" && key.shift) {
       // Shift+G to go to end
       setScrollOffset(0)
-    } else if (input === "g") {
+    } else if (input === "g" && !key.shift) {
       // g to go to beginning
       const filteredCount = logs.filter((log) => log.id > clearFromLogId).length
       setScrollOffset(Math.max(0, filteredCount - maxVisibleLogs))


### PR DESCRIPTION
## Motivation

Ink's `useInput` returns the inputted character as uppercase and lowercase. 

`console.log(input, key)` with "shift" + "g" will return:
```
G {
  upArrow: false,
  downArrow: false,
  leftArrow: false,
  rightArrow: false,
  pageDown: false,
  pageUp: false,
  return: false,
  escape: false,
  ctrl: false,
  shift: true,
  tab: false,
  backspace: false,
  delete: false,
  meta: false
}
```

## Changes

Read for uppercase `G` rather than lowercase `g`. Checking for `shift` is now redundant here, but I opted to keep it to be more verbose about what the expected input should be.