### PR TITLE
fix: strip ANSI codes before regex pattern construction

### DIFF
--- a/mcp-server/app/mcp/tools.ts
+++ b/mcp-server/app/mcp/tools.ts
@@ -197,7 +197,10 @@ function calculateErrorPriority(
   }
 
   // Count occurrences of similar errors
-  const errorPattern = errorLine.replace(/\d+/g, "\\d+").substring(0, 100)
+  // Strip ANSI escape codes before constructing regex pattern (fixes #74)
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes require control characters
+  const cleanLine = errorLine.replace(/\x1b\[[0-9;]*m/g, "")
+  const errorPattern = cleanLine.replace(/\d+/g, "\\d+").substring(0, 100)
   const occurrences = allErrors.filter((e) => new RegExp(errorPattern).test(e)).length
   if (occurrences > 1) {
     score += (occurrences - 1) * 50


### PR DESCRIPTION
Fixes #74

## Summary
ANSI escape codes in server logs cause `fix_my_app` to crash with regex parsing errors.

## Changes
- Strip ANSI codes before constructing the error pattern regex in `calculateErrorPriority()`

## Test
Reproduction script: https://gist.github.com/pro-vi/bb96ca8762b36c53d1b6a07589995325

```bash
bun https://gist.github.com/pro-vi/bb96ca8762b36c53d1b6a07589995325/raw
```