### PR TITLE
refactor: track spawned child processes for reliable monorepo cleanup

### DIFF
--- a/src/dev-environment.ts
+++ b/src/dev-environment.ts
@@ -3168,8 +3168,8 @@ export class DevEnvironment {
       // Wait briefly for graceful shutdown
       await new Promise((resolve) => setTimeout(resolve, 300))
 
-      // SIGKILL any remaining (force kill)
-      for (const pid of savedChildPids) {
+      // SIGKILL any remaining (force kill) - in reverse order to kill children before parents
+      for (const pid of [...savedChildPids].reverse()) {
         try {
           process.kill(pid, "SIGKILL")
           this.debugLog(`Force killed tracked PID ${pid}`)


### PR DESCRIPTION
## Summary
- Automatically tracks all child processes spawned by the server command (e.g., `turbo run dev`)
- Discovers ports opened by tracked processes
- Kills tracked PIDs on shutdown instead of requiring manual port specification

## How it works
1. After server is ready, runs `pgrep -P` recursively to discover all descendant processes
2. Uses `lsof` to find which ports those processes are listening on
3. Stores `childPids[]` and `managedPorts[]` in `~/.d3k/{project}/session.json`
4. On shutdown, kills all tracked PIDs (SIGTERM then SIGKILL), then falls back to port-based cleanup

## Test plan
- [ ] Start d3k with monorepo running `turbo run dev` with multiple services
- [ ] Verify `session.json` contains `childPids` and `managedPorts` arrays  
- [ ] Kill d3k with Ctrl+C
- [ ] Verify ALL spawned services are terminated
- [ ] Test in sandbox environment (graceful degradation when pgrep/lsof unavailable)

🤖 Generated with [Claude Code](https://claude.ai/code)