### PR TITLE
Add browser configuration support in user settings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -698,6 +698,9 @@ program
     const projectConfig = await detectProjectType(options.debug)
     const userConfigForMcp = loadUserConfig()
 
+    // Apply default browser from config if not explicitly provided
+    const browser = options.browser || userConfigForMcp.browser
+
     // Check if we're in a valid project directory
     if (projectConfig.noProjectDetected) {
       console.error(chalk.red("\n❌ No project detected in current directory.\n"))
@@ -831,6 +834,7 @@ program
 
       await startDevEnvironment({
         ...options,
+        browser,
         port,
         portMcp: options.portMcp,
         debugPort: Number.parseInt(debugPort, 10),

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -10,6 +10,7 @@ export interface AgentConfig {
 export interface UserConfig {
   disableMcpConfigs?: string
   defaultAgent?: AgentConfig
+  browser?: string
 }
 
 export function getUserConfigPath(): string {
@@ -50,6 +51,9 @@ export function loadUserConfig(): UserConfig {
         config.defaultAgent = { name: agent.name, command: agent.command }
       }
     }
+    if (typeof parsed.browser === "string" && parsed.browser.trim().length > 0) {
+      config.browser = parsed.browser.trim()
+    }
     return config
   } catch {
     return {}
@@ -72,6 +76,11 @@ export function saveUserConfig(updates: Partial<UserConfig>): void {
   // Remove defaultAgent if set to undefined (user chose "No agent")
   if (updates.defaultAgent === undefined && "defaultAgent" in updates) {
     delete merged.defaultAgent
+  }
+
+  // Remove browser if set to undefined
+  if (updates.browser === undefined && "browser" in updates) {
+    delete merged.browser
   }
 
   writeFileSync(configPath, JSON.stringify(merged, null, 2))


### PR DESCRIPTION
## Summary

Add support for configuring a default browser in user settings. Users can now set their preferred browser in `~/.d3k-config.json`, which will be used automatically when starting the dev environment instead of requiring the `--browser` flag each time.

## Changes

- Extended `UserConfig` interface to include optional `browser` field
- Modified `loadUserConfig()` to read and validate browser setting from config file
- Updated `saveUserConfig()` to properly handle browser configuration updates and deletions
- Applied default browser from user config in CLI when `--browser` flag is not explicitly provided
- Browser preference hierarchy: CLI flag > User config > System default

## Benefits

- Eliminates need to specify `--browser` flag repeatedly for users with a preferred browser
- Maintains backward compatibility - existing workflows continue to work
- Explicit CLI flag still takes precedence when provided