### PR TITLE
feat(cli): add --no-agent flag to skip agent selection prompt

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -577,6 +577,7 @@ program
     "--with-agent <command>",
     'Run an agent (e.g. claude) in split-screen mode using tmux. Example: --with-agent "claude"'
   )
+  .option("--no-agent", "Skip agent selection prompt and run d3k standalone")
   .action(async (options) => {
     // Handle --with-agent by spawning tmux with split panes
     if (options.withAgent) {
@@ -613,9 +614,9 @@ program
     }
 
     // Handle agent selection for split-screen mode (default behavior in TTY)
-    // Skip if --no-tui, --debug flags are used, or if already inside tmux (to avoid nested prompts)
+    // Skip if --no-agent, --no-tui, --debug flags are used, or if already inside tmux (to avoid nested prompts)
     const insideTmux = !!process.env.TMUX
-    if (process.stdin.isTTY && !options.noTui && !options.debug && !insideTmux) {
+    if (process.stdin.isTTY && options.agent !== false && options.tui !== false && !options.debug && !insideTmux) {
       // Clear the terminal so d3k UI starts at the top of the screen
       process.stdout.write("\x1B[2J\x1B[0f")
 


### PR DESCRIPTION
## Summary
- Adds `--no-agent` option to run d3k standalone without the agent selection menu

## Motivation
The CLI currently has `--with-agent <command>` to specify an agent, but there's no way to explicitly skip the agent selection prompt. This creates an asymmetry in the CLI interface and forces users who want standalone mode to use workarounds like `--no-tui` or `--debug`.

The `--no-agent` flag provides a clear, intuitive way to run d3k without the agent selection menu.

## Changes
- Add `--no-agent` option to the start command
- Fix Commander.js `--no-*` option handling: use `options.agent !== false` instead of checking undefined `options.noAgent` (Commander.js sets the positive form to `false` for `--no-*` options)

## Test plan
- [ ] Run `d3k --no-agent` - should start without agent selection prompt
- [ ] Run `d3k --with-agent claude` - should still work as before
- [ ] Run `d3k` (no flags) - should show agent selection prompt as before

🤖 Generated with [Claude Code](https://claude.ai/code)