### PR TITLE
Add Microsoft Edge to chromium-based browser discovery

### DIFF
--- a/src/cdp-monitor.ts
+++ b/src/cdp-monitor.ts
@@ -303,7 +303,8 @@ export class CDPMonitor {
             "chrome",
             "chromium",
             "/Applications/Arc.app/Contents/MacOS/Arc",
-            "/Applications/Comet.app/Contents/MacOS/Comet"
+            "/Applications/Comet.app/Contents/MacOS/Comet",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
           ]
 
       const browserType = this.browserPath ? "custom browser" : "Chrome"


### PR DESCRIPTION
## Summary
- Adds Microsoft Edge to the list of automatically discovered Chromium-based browsers on macOS

Fixes #85

## Test plan
- [x] Lint passes
- [x] TypeScript passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)