### PR TITLE
[BUG] Error: Cannot find module 'styled-jsx/package.json'

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,8 +37,8 @@
         "vitest": "^3.2.4",
       },
       "optionalDependencies": {
-        "@d3k/darwin-arm64": "0.0.150-canary",
-        "@d3k/linux-x64": "0.0.150-canary",
+        "@d3k/darwin-arm64": "0.0.151-canary",
+        "@d3k/linux-x64": "0.0.151-canary",
         "@opentui/core-linux-x64": "^0.1.71",
       },
     },
@@ -60,6 +60,7 @@
         "pngjs": "^7.0.0",
         "react": "19.3.0-canary-09f05694-20251201",
         "react-dom": "19.3.0-canary-09f05694-20251201",
+        "styled-jsx": "5.1.6",
         "tailwind-merge": "^2.6.0",
         "ws": "^8.18.3",
         "zod": "^3.22.4",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -21,6 +21,7 @@
     "mcp-handler": "1.0.2",
     "ms": "^2.1.3",
     "next": "16.1.0",
+    "styled-jsx": "5.1.6",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "react": "19.3.0-canary-09f05694-20251201",


### PR DESCRIPTION
## Summary
- Adds `styled-jsx` as a direct dependency in mcp-server/package.json
- Fixes MCP server crash: `Error: Cannot find module 'styled-jsx/package.json'`

## Root Cause
The `build-binaries.ts` script copies `mcp-server/node_modules` with `dereference:true`, but `styled-jsx` is a transitive dependency of Next.js - not a direct dependency of mcp-server. When dependencies are hoisted (as bun workspaces do), transitive deps don't get symlinked into the package's node_modules, so they're not copied during the build.

**Probable cause:** The [pnpm → bun migration](https://github.com/vercel-labs/dev3000/commit/21c0e1a) may have changed how dependencies are resolved/hoisted, exposing this latent issue.

## Fix
Adding `styled-jsx` as a direct dependency ensures it gets properly copied to the built package.

**Note:** bun.lock also syncs a pre-existing version mismatch (package.json had 0.0.151-canary, bun.lock had 0.0.150-canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)