### PR TITLE
Replace cdp-port command substitution with direct port usage in skill

### DIFF
--- a/src/skills/d3k/SKILL.md
+++ b/src/skills/d3k/SKILL.md
@@ -33,37 +33,38 @@ d3k find-component "nav"  # Find React component source
 
 ## Browser Interaction
 
-To click elements, navigate, or take screenshots, use `d3k agent-browser --cdp $(d3k cdp-port)`:
+First run `d3k cdp-port` to get the port number, then use it directly in all browser commands:
 
 ```bash
-d3k agent-browser --cdp $(d3k cdp-port) open http://localhost:3000/page
-d3k agent-browser --cdp $(d3k cdp-port) snapshot -i    # Get element refs (@e1, @e2)
-d3k agent-browser --cdp $(d3k cdp-port) click @e2
-d3k agent-browser --cdp $(d3k cdp-port) fill @e3 "text"
-d3k agent-browser --cdp $(d3k cdp-port) screenshot /tmp/shot.png
+d3k cdp-port                                          # Returns e.g. 9222
+d3k agent-browser --cdp 9222 open http://localhost:3000/page
+d3k agent-browser --cdp 9222 snapshot -i    # Get element refs (@e1, @e2)
+d3k agent-browser --cdp 9222 click @e2
+d3k agent-browser --cdp 9222 fill @e3 "text"
+d3k agent-browser --cdp 9222 screenshot /tmp/shot.png
 ```
 
 ## Fix Workflow
 
 1. `d3k errors --context` - See errors and what triggered them
 2. Fix the code
-3. `d3k agent-browser --cdp $(d3k cdp-port) open <url>` then `click @e1` to replay
+3. Run `d3k cdp-port` to get the port, then `d3k agent-browser --cdp <port> open <url>` then `click @e1` to replay
 4. `d3k errors` - Verify fix worked
 
 ## Creating PRs with Before/After Screenshots
 
 When creating a PR for visual changes, **always capture before/after screenshots** to show the impact:
 
-1. **Before making changes**, screenshot the production site:
+1. **Before making changes**, screenshot the production site (run `d3k cdp-port` first to get the port):
    ```bash
-   d3k agent-browser --cdp $(d3k cdp-port) open https://production-url.com/affected-page
-   d3k agent-browser --cdp $(d3k cdp-port) screenshot /tmp/before.png
+   d3k agent-browser --cdp <port> open https://production-url.com/affected-page
+   d3k agent-browser --cdp <port> screenshot /tmp/before.png
    ```
 
 2. **After making changes**, screenshot localhost:
    ```bash
-   d3k agent-browser --cdp $(d3k cdp-port) open http://localhost:3000/affected-page
-   d3k agent-browser --cdp $(d3k cdp-port) screenshot /tmp/after.png
+   d3k agent-browser --cdp <port> open http://localhost:3000/affected-page
+   d3k agent-browser --cdp <port> screenshot /tmp/after.png
    ```
 
 3. **Or use the tooling API** to capture multiple routes at once:


### PR DESCRIPTION
Avoids $(d3k cdp-port) in every browser command, which triggers an approval prompt each time. Now instructs agents to fetch the port once and use the literal value in subsequent commands.