### PR TITLE
Fix trace drain timeouts and blob path collisions

### DIFF
--- a/www/app/api/drain/traces/route.ts
+++ b/www/app/api/drain/traces/route.ts
@@ -94,11 +94,15 @@ export async function POST(request: Request) {
 
     // Write to Blob in background — respond immediately to avoid timeout
     after(async () => {
-      await put(blobPath, JSON.stringify(envelope), {
-        contentType: "application/json",
-        access: "public", // Blob requires access level; data isn't sensitive (trace telemetry)
-        addRandomSuffix: true
-      })
+      try {
+        await put(blobPath, JSON.stringify(envelope), {
+          contentType: "application/json",
+          access: "public", // Blob requires access level; data isn't sensitive (trace telemetry)
+          addRandomSuffix: true
+        })
+      } catch (error) {
+        console.error("[TraceDrain] Error writing trace to Blob storage:", error)
+      }
     })
 
     return Response.json({ accepted: spanCount })


### PR DESCRIPTION
## Summary

- [Reported in Slack](https://vercel.slack.com/archives/C07JUV4AW1L/p1774409815396099). 

- Use `next/server` `after()` to write to Blob in background, returning 200 immediately to prevent timeouts
- Use `addRandomSuffix: true` to let Blob handle path uniqueness, fixing overwrite errors

## Test plan
- [ ] Deploy and verify drain endpoint returns 200 quickly
- [ ] Confirm traces are stored in Blob without collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)