### PR TITLE
Add Brave browser to CDP auto-detection

### DIFF
--- a/src/cdp-monitor.ts
+++ b/src/cdp-monitor.ts
@@ -461,6 +461,8 @@ export class CDPMonitor {
             "google-chrome",
             "chrome",
             "chromium",
+            "brave",
+            "brave-browser",
             "/Applications/Arc.app/Contents/MacOS/Arc",
             "/Applications/Comet.app/Contents/MacOS/Comet",
             "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"


### PR DESCRIPTION
## Summary
- Adds `brave` and `brave-browser` to the Chromium executable fallback list in `launchChrome()`
- Brave is Chromium-based and supports CDP via `--remote-debugging-port`, making it a drop-in addition
- Without this, Linux users running Brave must always pass `--browser /usr/bin/brave` manually

## Details
- `brave` is the binary name on Arch-based distros (Arch, CachyOS, Manjaro, etc.)
- `brave-browser` is the binary name on Debian/Ubuntu
- Placed after `chromium` and before the macOS app bundle paths, matching the existing generic-first ordering

## Test plan
- [ ] Verified on CachyOS (Arch-based) with Brave at `/usr/bin/brave` — `d3k` launches Brave and connects via CDP without needing `--browser`
- [ ] Existing Chrome/Chromium detection is unaffected (Brave entries are only reached if earlier candidates aren't found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)