### PR TITLE
fix: scope all CLI commands to current directory in monorepos

### DIFF
--- a/src/commands/crawl.ts
+++ b/src/commands/crawl.ts
@@ -6,63 +6,17 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { existsSync, readdirSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import chalk from "chalk"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface CrawlOptions {
   depth?: string // 1, 2, 3, or "all"
   limit?: string // max links per page
 }
 
-interface Session {
-  projectName: string
-  appPort: string
-  publicUrl?: string | null
-  cdpUrl?: string
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessions: Session[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          try {
-            const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
-            if (content.pid) {
-              try {
-                process.kill(content.pid, 0)
-                sessions.push(content)
-              } catch {
-                // Process not running
-              }
-            }
-          } catch {
-            // Skip invalid files
-          }
-        }
-      }
-    }
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
 function runAgentBrowser(args: string[]): { success: boolean; output: string } {
   try {
-    const result = spawnSync("d3k", ["agent-browser", "--cdp", "9222", ...args], {
+    const result = spawnSync("d3k", ["agent-browser", ...args], {
       encoding: "utf-8",
       timeout: 30000
     })
@@ -81,15 +35,13 @@ export async function crawlApp(options: CrawlOptions): Promise<void> {
   const maxDepth = options.depth === "all" ? 10 : parseInt(options.depth || "1", 10)
   const limitPerPage = parseInt(options.limit || "3", 10)
 
-  const sessions = findActiveSessions()
+  const session = findCurrentSession()
 
-  if (sessions.length === 0) {
+  if (!session) {
     console.log(chalk.red("❌ No active d3k sessions found."))
     console.log(chalk.gray("Make sure d3k is running first."))
     process.exit(1)
   }
-
-  const session = sessions[0]
   const appPort = session.appPort || "3000"
   const baseUrl = session.publicUrl || `http://localhost:${appPort}`
 

--- a/src/commands/errors.ts
+++ b/src/commands/errors.ts
@@ -9,6 +9,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import chalk from "chalk"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface ErrorsOptions {
   count?: string // number of errors to show
@@ -17,70 +18,10 @@ export interface ErrorsOptions {
   json?: boolean // output as JSON
 }
 
-interface Session {
-  projectName: string
-  startTime: string
-  logFilePath: string
-  sessionFile: string
-  pid: number
-  lastModified: Date
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessionFiles: string[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          sessionFiles.push(sessionFile)
-        }
-      }
-    }
-
-    const sessions = sessionFiles
-      .map((filePath) => {
-        try {
-          const content = JSON.parse(readFileSync(filePath, "utf-8"))
-          const stat = statSync(filePath)
-          return {
-            ...content,
-            sessionFile: filePath,
-            lastModified: stat.mtime
-          }
-        } catch {
-          return null
-        }
-      })
-      .filter((session): session is Session => {
-        if (!session || !session.pid) return false
-        try {
-          process.kill(session.pid, 0)
-          return true
-        } catch {
-          return false
-        }
-      })
-      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
 function getLogPath(): string | null {
-  // First check for active sessions
-  const sessions = findActiveSessions()
-  if (sessions.length > 0) {
-    return sessions[0].logFilePath
+  const session = findCurrentSession()
+  if (session) {
+    return session.logFilePath
   }
 
   // Fall back to environment variable

--- a/src/commands/find-component.ts
+++ b/src/commands/find-component.ts
@@ -6,56 +6,12 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { existsSync, readdirSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import chalk from "chalk"
-
-interface Session {
-  projectName: string
-  cdpUrl?: string
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessions: Session[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          try {
-            const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
-            if (content.pid) {
-              try {
-                process.kill(content.pid, 0)
-                sessions.push(content)
-              } catch {
-                // Process not running
-              }
-            }
-          } catch {
-            // Skip invalid files
-          }
-        }
-      }
-    }
-
-    return sessions
-  } catch {
-    return []
-  }
-}
+import { findCurrentSession } from "../utils/session.js"
 
 function runAgentBrowser(args: string[]): { success: boolean; output: string } {
   try {
-    const result = spawnSync("d3k", ["agent-browser", "--cdp", "9222", ...args], {
+    const result = spawnSync("d3k", ["agent-browser", ...args], {
       encoding: "utf-8",
       timeout: 30000
     })
@@ -71,9 +27,9 @@ function runAgentBrowser(args: string[]): { success: boolean; output: string } {
 }
 
 export async function findComponent(selector: string): Promise<void> {
-  const sessions = findActiveSessions()
+  const session = findCurrentSession()
 
-  if (sessions.length === 0) {
+  if (!session) {
     console.log(chalk.red("❌ No active d3k sessions found."))
     console.log(chalk.gray("Make sure d3k is running first."))
     process.exit(1)

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -5,24 +5,14 @@
  * Returns a prioritized list of issues that need to be fixed.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
+import { existsSync, readFileSync } from "node:fs"
 import chalk from "chalk"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface FixOptions {
   focus?: string // build, runtime, network, ui, all
   time?: string // minutes to look back
   json?: boolean
-}
-
-interface Session {
-  projectName: string
-  startTime: string
-  logFilePath: string
-  sessionFile: string
-  pid: number
-  lastModified: Date
 }
 
 interface CategorizedErrors {
@@ -31,73 +21,6 @@ interface CategorizedErrors {
   buildErrors: string[]
   networkErrors: string[]
   warnings: string[]
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessionFiles: string[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          sessionFiles.push(sessionFile)
-        }
-      }
-    }
-
-    const sessions = sessionFiles
-      .map((filePath) => {
-        try {
-          const content = JSON.parse(readFileSync(filePath, "utf-8"))
-          const stat = statSync(filePath)
-          return {
-            ...content,
-            sessionFile: filePath,
-            lastModified: stat.mtime
-          }
-        } catch {
-          return null
-        }
-      })
-      .filter((session): session is Session => {
-        if (!session || !session.pid) return false
-        try {
-          process.kill(session.pid, 0)
-          return true
-        } catch {
-          return false
-        }
-      })
-      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
-function getLogPath(projectName?: string): string | null {
-  if (projectName) {
-    const sessions = findActiveSessions()
-    const session = sessions.find((s) => s.projectName === projectName)
-    if (session) {
-      return session.logFilePath
-    }
-  }
-
-  const envPath = process.env.LOG_FILE_PATH
-  if (envPath) {
-    return envPath
-  }
-
-  return null
 }
 
 function findInteractionsBeforeError(errorLine: string, allLines: string[]): string[] {
@@ -122,9 +45,9 @@ export async function fixMyApp(options: FixOptions): Promise<void> {
   const timeRangeMinutes = parseInt(options.time || "10", 10)
   const outputJson = options.json || false
 
-  const sessions = findActiveSessions()
+  const session = findCurrentSession()
 
-  if (sessions.length === 0) {
+  if (!session) {
     if (outputJson) {
       console.log(JSON.stringify({ error: "No active d3k sessions found" }))
     } else {
@@ -134,12 +57,10 @@ export async function fixMyApp(options: FixOptions): Promise<void> {
     process.exit(1)
   }
 
-  // Auto-select if only one session
-  const session = sessions[0]
   let logPath: string | null = session.logFilePath
 
   if (!logPath) {
-    logPath = getLogPath(session.projectName)
+    logPath = process.env.LOG_FILE_PATH || null
   }
 
   if (!logPath) {

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -8,7 +8,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import chalk from "chalk"
-import { getProjectName } from "../utils/project-name.js"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface LogsOptions {
   count?: string // number of lines to show
@@ -17,72 +17,11 @@ export interface LogsOptions {
   json?: boolean
 }
 
-interface Session {
-  projectName: string
-  startTime: string
-  logFilePath: string
-  sessionFile: string
-  pid: number
-  lastModified: Date
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessionFiles: string[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          sessionFiles.push(sessionFile)
-        }
-      }
-    }
-
-    const sessions = sessionFiles
-      .map((filePath) => {
-        try {
-          const content = JSON.parse(readFileSync(filePath, "utf-8"))
-          const stat = statSync(filePath)
-          return {
-            ...content,
-            sessionFile: filePath,
-            lastModified: stat.mtime
-          }
-        } catch {
-          return null
-        }
-      })
-      .filter((session): session is Session => {
-        if (!session || !session.pid) return false
-        try {
-          process.kill(session.pid, 0)
-          return true
-        } catch {
-          return false
-        }
-      })
-      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
 function getLogPath(): string | null {
   // First check for active sessions, preferring the one matching the current directory
-  const sessions = findActiveSessions()
-  if (sessions.length > 0) {
-    const currentProject = getProjectName()
-    const matchingSession = sessions.find((s) => s.projectName === currentProject)
-    return (matchingSession || sessions[0]).logFilePath
+  const session = findCurrentSession()
+  if (session) {
+    return session.logFilePath
   }
 
   // Fall back to environment variable

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -8,6 +8,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import chalk from "chalk"
+import { getProjectName } from "../utils/project-name.js"
 
 export interface LogsOptions {
   count?: string // number of lines to show
@@ -76,10 +77,12 @@ function findActiveSessions(): Session[] {
 }
 
 function getLogPath(): string | null {
-  // First check for active sessions
+  // First check for active sessions, preferring the one matching the current directory
   const sessions = findActiveSessions()
   if (sessions.length > 0) {
-    return sessions[0].logFilePath
+    const currentProject = getProjectName()
+    const matchingSession = sessions.find((s) => s.projectName === currentProject)
+    return (matchingSession || sessions[0]).logFilePath
   }
 
   // Fall back to environment variable

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared session discovery for d3k CLI commands.
+ *
+ * Finds active d3k sessions by scanning ~/.d3k/{project}/session.json,
+ * preferring the session that matches the current working directory.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { getProjectName } from "./project-name.js"
+
+export interface Session {
+  projectName: string
+  startTime: string
+  logFilePath: string
+  sessionFile: string
+  pid: number
+  lastModified: Date
+  appPort?: string
+  publicUrl?: string | null
+  cdpUrl?: string | null
+}
+
+/**
+ * Find all active d3k sessions, sorted by startTime (most recent first).
+ */
+export function findActiveSessions(): Session[] {
+  const sessionDir = join(homedir(), ".d3k")
+  if (!existsSync(sessionDir)) {
+    return []
+  }
+
+  try {
+    const entries = readdirSync(sessionDir, { withFileTypes: true })
+    const sessionFiles: string[] = []
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const sessionFile = join(sessionDir, entry.name, "session.json")
+        if (existsSync(sessionFile)) {
+          sessionFiles.push(sessionFile)
+        }
+      }
+    }
+
+    return sessionFiles
+      .map((filePath) => {
+        try {
+          const content = JSON.parse(readFileSync(filePath, "utf-8"))
+          const stat = statSync(filePath)
+          return {
+            ...content,
+            sessionFile: filePath,
+            lastModified: stat.mtime
+          }
+        } catch {
+          return null
+        }
+      })
+      .filter((session): session is Session => {
+        if (!session || !session.pid) return false
+        try {
+          process.kill(session.pid, 0)
+          return true
+        } catch {
+          return false
+        }
+      })
+      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Find the active session for the current working directory.
+ * Falls back to the most recent session if no exact match is found.
+ */
+export function findCurrentSession(): Session | null {
+  const sessions = findActiveSessions()
+  if (sessions.length === 0) return null
+
+  const currentProject = getProjectName()
+  return sessions.find((s) => s.projectName === currentProject) || sessions[0]
+}


### PR DESCRIPTION
## Problem

In a monorepo with multiple `d3k` instances running simultaneously, every CLI command that reads session data picks the most recently started session globally — not the one for the current working directory.

Affected commands: `logs`, `errors`, `fix`, `crawl`, `find-component`.

Each command had its own copy of `findActiveSessions()` (duplicated 5 times) that returned `sessions[0]` sorted by `startTime` without checking `projectName`.

Additionally, `crawl` and `find-component` hardcoded `--cdp 9222` instead of using the session's actual CDP port.

## Fix

1. **Extract shared `utils/session.ts`** with `findActiveSessions()` and `findCurrentSession()` — uses `getProjectName()` to match the current directory's session, falls back to most recent if no match found.

2. **Replace all 5 copies** in `logs.ts`, `errors.ts`, `fix.ts`, `crawl.ts`, `find-component.ts` with imports from the shared util.

3. **Remove hardcoded `--cdp 9222`** from `crawl` and `find-component` — they now call `d3k agent-browser` without `--cdp`, relying on the auto-inject from the session (see #103).

**Net: -312 lines, +107 lines.**

## Commands audited

| Command | Before | After |
|---------|--------|-------|
| `d3k logs` | `sessions[0]` | `findCurrentSession()` |
| `d3k errors` | `sessions[0]` | `findCurrentSession()` |
| `d3k fix` | `sessions[0]` | `findCurrentSession()` |
| `d3k crawl` | `sessions[0]` + hardcoded CDP 9222 | `findCurrentSession()` + no hardcoded CDP |
| `d3k find-component` | `sessions[0]` + hardcoded CDP 9222 | `findCurrentSession()` + no hardcoded CDP |
| `d3k resume` | Already uses `cwd` | No change needed |
| `d3k agent-browser` | See #103 | See #103 |
| `d3k cdp-port` | See #103 | See #103 |

All 227 existing tests pass. Happy to adjust if this doesn't match your intended design.