### PR TITLE
fix: auto-inject `--cdp` from session into `d3k agent-browser`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,15 +182,16 @@ function runLocalBrowserTool(browserTool: LocalBrowserTool, args: string[]) {
       process.exit(result.status ?? 0)
     }
 
-    // Auto-inject --cdp from session if not already provided
-    if (!args.includes("--cdp")) {
+    const binaryPath = findAgentBrowser()
+
+    // Auto-connect to session CDP if user didn't provide --cdp or an explicit connect
+    if (!args.includes("--cdp") && subcommand !== "connect") {
       const cdpPort = getSessionCdpPort()
       if (cdpPort) {
-        args = ["--cdp", cdpPort, ...args]
+        spawnSync(binaryPath, ["connect", cdpPort], { stdio: "pipe", shell: false, env })
       }
     }
 
-    const binaryPath = findAgentBrowser()
     const result = spawnSync(binaryPath, args, {
       stdio: "pipe",
       shell: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,21 @@ function getProjectBrowserToolPreference(): LocalBrowserTool {
   }
 }
 
+function getSessionCdpPort(): string | null {
+  const sessionFile = join(getProjectDir(), "session.json")
+  if (!existsSync(sessionFile)) return null
+  try {
+    const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
+    if (content.cdpUrl) {
+      const match = content.cdpUrl.match(/:(\d+)/)
+      if (match) return match[1]
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
 function runLocalBrowserTool(browserTool: LocalBrowserTool, args: string[]) {
   const env = { ...process.env }
   ensureCommandPath(env)
@@ -165,6 +180,14 @@ function runLocalBrowserTool(browserTool: LocalBrowserTool, args: string[]) {
       const d3kBin = process.argv[1]
       const result = spawnSync(d3kBin, ["logs", "--type", "browser"], { stdio: "inherit", shell: false })
       process.exit(result.status ?? 0)
+    }
+
+    // Auto-inject --cdp from session if not already provided
+    if (!args.includes("--cdp")) {
+      const cdpPort = getSessionCdpPort()
+      if (cdpPort) {
+        args = ["--cdp", cdpPort, ...args]
+      }
     }
 
     const binaryPath = findAgentBrowser()
@@ -1559,39 +1582,8 @@ program
 program
   .command("cdp-port")
   .description("Output the CDP port for the current d3k session (for use in scripts)")
-  .action(async () => {
-    const sessionDir = join(homedir(), ".d3k")
-    const projectDir = getProjectDir()
-    const projectName = projectDir.split("/").pop() || "unknown"
-
-    // Try to find session.json in ~/.d3k/{project-name}/
-    const entries = existsSync(sessionDir)
-      ? await import("fs").then((fs) => fs.readdirSync(sessionDir, { withFileTypes: true }))
-      : []
-
-    for (const entry of entries) {
-      if (entry.isDirectory() && entry.name.startsWith(projectName.substring(0, 20))) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          try {
-            const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
-            if (content.cdpUrl) {
-              // Extract port from URL like "ws://localhost:9223/devtools/browser/..."
-              const match = content.cdpUrl.match(/:(\d+)/)
-              if (match) {
-                console.log(match[1])
-                process.exit(0)
-              }
-            }
-          } catch {
-            // Continue searching
-          }
-        }
-      }
-    }
-
-    // Default to 9222 if no session found
-    console.log("9222")
+  .action(() => {
+    console.log(getSessionCdpPort() || "9222")
   })
 
 program.parse()


### PR DESCRIPTION
## Problem

Every `d3k agent-browser` invocation requires `--cdp $(d3k cdp-port)` because the passthrough doesn't use session info.

## Fix

Auto-run `agent-browser connect <port>` (using the session's CDP port) before forwarding the user's command. This establishes a persistent daemon connection so subsequent commands target the correct browser.

We use `connect` instead of `--cdp` because `--cdp <port>` is currently broken in agent-browser (always falls back to 9222), while `connect <port>` works correctly via the daemon.

```bash
# Before: required
d3k agent-browser --cdp $(d3k cdp-port) open http://localhost:3000

# After: just works
d3k agent-browser open http://localhost:3000
```

Skipped when user passes `--cdp` explicitly or runs `connect` manually.

Also extracts `getSessionCdpPort()` as a shared helper, simplifying the `cdp-port` command.

Note: depends on #102 for correct directory scoping of session lookup.