### PR TITLE
docs: simplify agent-browser usage (auto CDP connect)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,10 @@ This file is the source of truth for agent guidance in this repo. `CLAUDE.md` is
   ```
 - Drive the monitored browser with:
   ```bash
-  CDP_PORT="$(d3k cdp-port)"
-  d3k agent-browser --cdp "$CDP_PORT" snapshot -i
-  d3k agent-browser --cdp "$CDP_PORT" click @e2
+  d3k agent-browser snapshot -i
+  d3k agent-browser click @e2
   ```
+  The session's CDP port is auto-connected. To target a different session: `d3k agent-browser connect <port>` first.
 
 ## Local UI, Production Workflows
 

--- a/skills/d3k/SKILL.md
+++ b/skills/d3k/SKILL.md
@@ -52,12 +52,13 @@ d3k logs --type server
 Use the already-monitored browser session instead of launching a separate automation browser.
 
 ```bash
-CDP_PORT="$(d3k cdp-port)"
-d3k agent-browser --cdp "$CDP_PORT" open http://localhost:3000
-d3k agent-browser --cdp "$CDP_PORT" snapshot -i
-d3k agent-browser --cdp "$CDP_PORT" click @e2
-d3k agent-browser --cdp "$CDP_PORT" screenshot /tmp/d3k-current.png
+d3k agent-browser open http://localhost:3000
+d3k agent-browser snapshot -i
+d3k agent-browser click @e2
+d3k agent-browser screenshot /tmp/d3k-current.png
 ```
+
+`d3k agent-browser` auto-connects to the active session's browser via CDP. To target a different browser: `d3k agent-browser connect <port>` first.
 
 ## Browser Tool Choice
 
@@ -71,7 +72,7 @@ Use the browser tool that matches the task instead of treating them as interchan
   - Next.js-specific tool.
   - Best for React/Next introspection: `tree`, `errors`, `logs`, `routes`, `project`, PPR inspection, and related Next dev-server signals.
   - It is not a drop-in replacement for `agent-browser`: no accessibility `snapshot`, no ref-based `click`, and no `fill`.
-  - It launches its own daemon/browser flow and does not use `d3k cdp-port`.
+  - It launches its own daemon/browser flow and does not use the d3k session's CDP port.
 
 Practical rule:
 
@@ -81,10 +82,9 @@ Practical rule:
 Examples:
 
 ```bash
-# Same monitored browser session
-CDP_PORT="$(d3k cdp-port)"
-d3k agent-browser --cdp "$CDP_PORT" snapshot -i
-d3k agent-browser --cdp "$CDP_PORT" click @e2
+# Same monitored browser session (auto-connected)
+d3k agent-browser snapshot -i
+d3k agent-browser click @e2
 
 # Next.js-specific inspection
 d3k next-browser open http://localhost:3000

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,15 +182,16 @@ function runLocalBrowserTool(browserTool: LocalBrowserTool, args: string[]) {
       process.exit(result.status ?? 0)
     }
 
-    // Auto-inject --cdp from session if not already provided
-    if (!args.includes("--cdp")) {
+    const binaryPath = findAgentBrowser()
+
+    // Auto-connect to session CDP if user didn't provide --cdp or an explicit connect
+    if (!args.includes("--cdp") && subcommand !== "connect") {
       const cdpPort = getSessionCdpPort()
       if (cdpPort) {
-        args = ["--cdp", cdpPort, ...args]
+        spawnSync(binaryPath, ["connect", cdpPort], { stdio: "pipe", shell: false, env })
       }
     }
 
-    const binaryPath = findAgentBrowser()
     const result = spawnSync(binaryPath, args, {
       stdio: "pipe",
       shell: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,21 @@ function getProjectBrowserToolPreference(): LocalBrowserTool {
   }
 }
 
+function getSessionCdpPort(): string | null {
+  const sessionFile = join(getProjectDir(), "session.json")
+  if (!existsSync(sessionFile)) return null
+  try {
+    const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
+    if (content.cdpUrl) {
+      const match = content.cdpUrl.match(/:(\d+)/)
+      if (match) return match[1]
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
 function runLocalBrowserTool(browserTool: LocalBrowserTool, args: string[]) {
   const env = { ...process.env }
   ensureCommandPath(env)
@@ -165,6 +180,14 @@ function runLocalBrowserTool(browserTool: LocalBrowserTool, args: string[]) {
       const d3kBin = process.argv[1]
       const result = spawnSync(d3kBin, ["logs", "--type", "browser"], { stdio: "inherit", shell: false })
       process.exit(result.status ?? 0)
+    }
+
+    // Auto-inject --cdp from session if not already provided
+    if (!args.includes("--cdp")) {
+      const cdpPort = getSessionCdpPort()
+      if (cdpPort) {
+        args = ["--cdp", cdpPort, ...args]
+      }
     }
 
     const binaryPath = findAgentBrowser()
@@ -1559,39 +1582,8 @@ program
 program
   .command("cdp-port")
   .description("Output the CDP port for the current d3k session (for use in scripts)")
-  .action(async () => {
-    const sessionDir = join(homedir(), ".d3k")
-    const projectDir = getProjectDir()
-    const projectName = projectDir.split("/").pop() || "unknown"
-
-    // Try to find session.json in ~/.d3k/{project-name}/
-    const entries = existsSync(sessionDir)
-      ? await import("fs").then((fs) => fs.readdirSync(sessionDir, { withFileTypes: true }))
-      : []
-
-    for (const entry of entries) {
-      if (entry.isDirectory() && entry.name.startsWith(projectName.substring(0, 20))) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          try {
-            const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
-            if (content.cdpUrl) {
-              // Extract port from URL like "ws://localhost:9223/devtools/browser/..."
-              const match = content.cdpUrl.match(/:(\d+)/)
-              if (match) {
-                console.log(match[1])
-                process.exit(0)
-              }
-            }
-          } catch {
-            // Continue searching
-          }
-        }
-      }
-    }
-
-    // Default to 9222 if no session found
-    console.log("9222")
+  .action(() => {
+    console.log(getSessionCdpPort() || "9222")
   })
 
 program.parse()

--- a/src/commands/crawl.ts
+++ b/src/commands/crawl.ts
@@ -6,63 +6,17 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { existsSync, readdirSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import chalk from "chalk"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface CrawlOptions {
   depth?: string // 1, 2, 3, or "all"
   limit?: string // max links per page
 }
 
-interface Session {
-  projectName: string
-  appPort: string
-  publicUrl?: string | null
-  cdpUrl?: string
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessions: Session[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          try {
-            const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
-            if (content.pid) {
-              try {
-                process.kill(content.pid, 0)
-                sessions.push(content)
-              } catch {
-                // Process not running
-              }
-            }
-          } catch {
-            // Skip invalid files
-          }
-        }
-      }
-    }
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
 function runAgentBrowser(args: string[]): { success: boolean; output: string } {
   try {
-    const result = spawnSync("d3k", ["agent-browser", "--cdp", "9222", ...args], {
+    const result = spawnSync("d3k", ["agent-browser", ...args], {
       encoding: "utf-8",
       timeout: 30000
     })
@@ -81,15 +35,13 @@ export async function crawlApp(options: CrawlOptions): Promise<void> {
   const maxDepth = options.depth === "all" ? 10 : parseInt(options.depth || "1", 10)
   const limitPerPage = parseInt(options.limit || "3", 10)
 
-  const sessions = findActiveSessions()
+  const session = findCurrentSession()
 
-  if (sessions.length === 0) {
+  if (!session) {
     console.log(chalk.red("❌ No active d3k sessions found."))
     console.log(chalk.gray("Make sure d3k is running first."))
     process.exit(1)
   }
-
-  const session = sessions[0]
   const appPort = session.appPort || "3000"
   const baseUrl = session.publicUrl || `http://localhost:${appPort}`
 

--- a/src/commands/errors.ts
+++ b/src/commands/errors.ts
@@ -9,6 +9,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import chalk from "chalk"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface ErrorsOptions {
   count?: string // number of errors to show
@@ -17,70 +18,10 @@ export interface ErrorsOptions {
   json?: boolean // output as JSON
 }
 
-interface Session {
-  projectName: string
-  startTime: string
-  logFilePath: string
-  sessionFile: string
-  pid: number
-  lastModified: Date
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessionFiles: string[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          sessionFiles.push(sessionFile)
-        }
-      }
-    }
-
-    const sessions = sessionFiles
-      .map((filePath) => {
-        try {
-          const content = JSON.parse(readFileSync(filePath, "utf-8"))
-          const stat = statSync(filePath)
-          return {
-            ...content,
-            sessionFile: filePath,
-            lastModified: stat.mtime
-          }
-        } catch {
-          return null
-        }
-      })
-      .filter((session): session is Session => {
-        if (!session || !session.pid) return false
-        try {
-          process.kill(session.pid, 0)
-          return true
-        } catch {
-          return false
-        }
-      })
-      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
 function getLogPath(): string | null {
-  // First check for active sessions
-  const sessions = findActiveSessions()
-  if (sessions.length > 0) {
-    return sessions[0].logFilePath
+  const session = findCurrentSession()
+  if (session) {
+    return session.logFilePath
   }
 
   // Fall back to environment variable

--- a/src/commands/find-component.ts
+++ b/src/commands/find-component.ts
@@ -6,56 +6,12 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { existsSync, readdirSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
 import chalk from "chalk"
-
-interface Session {
-  projectName: string
-  cdpUrl?: string
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessions: Session[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          try {
-            const content = JSON.parse(readFileSync(sessionFile, "utf-8"))
-            if (content.pid) {
-              try {
-                process.kill(content.pid, 0)
-                sessions.push(content)
-              } catch {
-                // Process not running
-              }
-            }
-          } catch {
-            // Skip invalid files
-          }
-        }
-      }
-    }
-
-    return sessions
-  } catch {
-    return []
-  }
-}
+import { findCurrentSession } from "../utils/session.js"
 
 function runAgentBrowser(args: string[]): { success: boolean; output: string } {
   try {
-    const result = spawnSync("d3k", ["agent-browser", "--cdp", "9222", ...args], {
+    const result = spawnSync("d3k", ["agent-browser", ...args], {
       encoding: "utf-8",
       timeout: 30000
     })
@@ -71,9 +27,9 @@ function runAgentBrowser(args: string[]): { success: boolean; output: string } {
 }
 
 export async function findComponent(selector: string): Promise<void> {
-  const sessions = findActiveSessions()
+  const session = findCurrentSession()
 
-  if (sessions.length === 0) {
+  if (!session) {
     console.log(chalk.red("❌ No active d3k sessions found."))
     console.log(chalk.gray("Make sure d3k is running first."))
     process.exit(1)

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -5,24 +5,14 @@
  * Returns a prioritized list of issues that need to be fixed.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
+import { existsSync, readFileSync } from "node:fs"
 import chalk from "chalk"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface FixOptions {
   focus?: string // build, runtime, network, ui, all
   time?: string // minutes to look back
   json?: boolean
-}
-
-interface Session {
-  projectName: string
-  startTime: string
-  logFilePath: string
-  sessionFile: string
-  pid: number
-  lastModified: Date
 }
 
 interface CategorizedErrors {
@@ -31,73 +21,6 @@ interface CategorizedErrors {
   buildErrors: string[]
   networkErrors: string[]
   warnings: string[]
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessionFiles: string[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          sessionFiles.push(sessionFile)
-        }
-      }
-    }
-
-    const sessions = sessionFiles
-      .map((filePath) => {
-        try {
-          const content = JSON.parse(readFileSync(filePath, "utf-8"))
-          const stat = statSync(filePath)
-          return {
-            ...content,
-            sessionFile: filePath,
-            lastModified: stat.mtime
-          }
-        } catch {
-          return null
-        }
-      })
-      .filter((session): session is Session => {
-        if (!session || !session.pid) return false
-        try {
-          process.kill(session.pid, 0)
-          return true
-        } catch {
-          return false
-        }
-      })
-      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
-function getLogPath(projectName?: string): string | null {
-  if (projectName) {
-    const sessions = findActiveSessions()
-    const session = sessions.find((s) => s.projectName === projectName)
-    if (session) {
-      return session.logFilePath
-    }
-  }
-
-  const envPath = process.env.LOG_FILE_PATH
-  if (envPath) {
-    return envPath
-  }
-
-  return null
 }
 
 function findInteractionsBeforeError(errorLine: string, allLines: string[]): string[] {
@@ -122,9 +45,9 @@ export async function fixMyApp(options: FixOptions): Promise<void> {
   const timeRangeMinutes = parseInt(options.time || "10", 10)
   const outputJson = options.json || false
 
-  const sessions = findActiveSessions()
+  const session = findCurrentSession()
 
-  if (sessions.length === 0) {
+  if (!session) {
     if (outputJson) {
       console.log(JSON.stringify({ error: "No active d3k sessions found" }))
     } else {
@@ -134,12 +57,10 @@ export async function fixMyApp(options: FixOptions): Promise<void> {
     process.exit(1)
   }
 
-  // Auto-select if only one session
-  const session = sessions[0]
   let logPath: string | null = session.logFilePath
 
   if (!logPath) {
-    logPath = getLogPath(session.projectName)
+    logPath = process.env.LOG_FILE_PATH || null
   }
 
   if (!logPath) {

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -8,7 +8,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import chalk from "chalk"
-import { getProjectName } from "../utils/project-name.js"
+import { findCurrentSession } from "../utils/session.js"
 
 export interface LogsOptions {
   count?: string // number of lines to show
@@ -17,72 +17,11 @@ export interface LogsOptions {
   json?: boolean
 }
 
-interface Session {
-  projectName: string
-  startTime: string
-  logFilePath: string
-  sessionFile: string
-  pid: number
-  lastModified: Date
-}
-
-function findActiveSessions(): Session[] {
-  const sessionDir = join(homedir(), ".d3k")
-  if (!existsSync(sessionDir)) {
-    return []
-  }
-
-  try {
-    const entries = readdirSync(sessionDir, { withFileTypes: true })
-    const sessionFiles: string[] = []
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionFile = join(sessionDir, entry.name, "session.json")
-        if (existsSync(sessionFile)) {
-          sessionFiles.push(sessionFile)
-        }
-      }
-    }
-
-    const sessions = sessionFiles
-      .map((filePath) => {
-        try {
-          const content = JSON.parse(readFileSync(filePath, "utf-8"))
-          const stat = statSync(filePath)
-          return {
-            ...content,
-            sessionFile: filePath,
-            lastModified: stat.mtime
-          }
-        } catch {
-          return null
-        }
-      })
-      .filter((session): session is Session => {
-        if (!session || !session.pid) return false
-        try {
-          process.kill(session.pid, 0)
-          return true
-        } catch {
-          return false
-        }
-      })
-      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
-
-    return sessions
-  } catch {
-    return []
-  }
-}
-
 function getLogPath(): string | null {
   // First check for active sessions, preferring the one matching the current directory
-  const sessions = findActiveSessions()
-  if (sessions.length > 0) {
-    const currentProject = getProjectName()
-    const matchingSession = sessions.find((s) => s.projectName === currentProject)
-    return (matchingSession || sessions[0]).logFilePath
+  const session = findCurrentSession()
+  if (session) {
+    return session.logFilePath
   }
 
   // Fall back to environment variable

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -8,6 +8,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import chalk from "chalk"
+import { getProjectName } from "../utils/project-name.js"
 
 export interface LogsOptions {
   count?: string // number of lines to show
@@ -76,10 +77,12 @@ function findActiveSessions(): Session[] {
 }
 
 function getLogPath(): string | null {
-  // First check for active sessions
+  // First check for active sessions, preferring the one matching the current directory
   const sessions = findActiveSessions()
   if (sessions.length > 0) {
-    return sessions[0].logFilePath
+    const currentProject = getProjectName()
+    const matchingSession = sessions.find((s) => s.projectName === currentProject)
+    return (matchingSession || sessions[0]).logFilePath
   }
 
   // Fall back to environment variable

--- a/src/skills/d3k/SKILL.md
+++ b/src/skills/d3k/SKILL.md
@@ -33,16 +33,17 @@ d3k find-component "nav"  # Find React component source
 
 ## Browser Interaction
 
-First run `d3k cdp-port` to get the port number, then use it directly in all browser commands:
+`d3k agent-browser` auto-connects to the active session's browser via CDP:
 
 ```bash
-d3k cdp-port                                          # Returns e.g. 9222
-d3k agent-browser --cdp 9222 open http://localhost:3000/page
-d3k agent-browser --cdp 9222 snapshot -i    # Get element refs (@e1, @e2)
-d3k agent-browser --cdp 9222 click @e2
-d3k agent-browser --cdp 9222 fill @e3 "text"
-d3k agent-browser --cdp 9222 screenshot /tmp/shot.png
+d3k agent-browser open http://localhost:3000/page
+d3k agent-browser snapshot -i    # Get element refs (@e1, @e2)
+d3k agent-browser click @e2
+d3k agent-browser fill @e3 "text"
+d3k agent-browser screenshot /tmp/shot.png
 ```
+
+To target a different browser: `d3k agent-browser connect <port>` first.
 
 ## Browser Tool Choice
 
@@ -56,7 +57,7 @@ Use the browser tool that matches the task:
   - Next.js-specific tool.
   - Best for Next/React introspection: `tree`, `errors`, `logs`, `routes`, `project`, and related Next dev-server diagnostics.
   - It is not a drop-in replacement for `agent-browser`: no accessibility `snapshot`, no ref-based `click`, and no `fill`.
-  - It runs its own daemon/browser flow and does not use `d3k cdp-port`.
+  - It runs its own daemon/browser flow and does not use the d3k session's CDP port.
 
 Practical rule:
 
@@ -66,9 +67,9 @@ Practical rule:
 Examples:
 
 ```bash
-# Same monitored browser session
-d3k agent-browser --cdp 9222 snapshot -i
-d3k agent-browser --cdp 9222 click @e2
+# Same monitored browser session (auto-connected)
+d3k agent-browser snapshot -i
+d3k agent-browser click @e2
 
 # Next.js-specific inspection
 d3k next-browser open http://localhost:3000
@@ -88,23 +89,23 @@ d3k --browser-tool next-browser
 
 1. `d3k errors --context` - See errors and what triggered them
 2. Fix the code
-3. Run `d3k cdp-port` to get the port, then `d3k agent-browser --cdp <port> open <url>` then `click @e1` to replay
+3. `d3k agent-browser open <url>` then `d3k agent-browser click @e1` to replay
 4. `d3k errors` - Verify fix worked
 
 ## Creating PRs with Before/After Screenshots
 
 When creating a PR for visual changes, **always capture before/after screenshots** to show the impact:
 
-1. **Before making changes**, screenshot the production site (run `d3k cdp-port` first to get the port):
+1. **Before making changes**, screenshot the production site:
    ```bash
-   d3k agent-browser --cdp <port> open https://production-url.com/affected-page
-   d3k agent-browser --cdp <port> screenshot /tmp/before.png
+   d3k agent-browser open https://production-url.com/affected-page
+   d3k agent-browser screenshot /tmp/before.png
    ```
 
 2. **After making changes**, screenshot localhost:
    ```bash
-   d3k agent-browser --cdp <port> open http://localhost:3000/affected-page
-   d3k agent-browser --cdp <port> screenshot /tmp/after.png
+   d3k agent-browser open http://localhost:3000/affected-page
+   d3k agent-browser screenshot /tmp/after.png
    ```
 
 3. **Or use the tooling API** to capture multiple routes at once:

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared session discovery for d3k CLI commands.
+ *
+ * Finds active d3k sessions by scanning ~/.d3k/{project}/session.json,
+ * preferring the session that matches the current working directory.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { getProjectName } from "./project-name.js"
+
+export interface Session {
+  projectName: string
+  startTime: string
+  logFilePath: string
+  sessionFile: string
+  pid: number
+  lastModified: Date
+  appPort?: string
+  publicUrl?: string | null
+  cdpUrl?: string | null
+}
+
+/**
+ * Find all active d3k sessions, sorted by startTime (most recent first).
+ */
+export function findActiveSessions(): Session[] {
+  const sessionDir = join(homedir(), ".d3k")
+  if (!existsSync(sessionDir)) {
+    return []
+  }
+
+  try {
+    const entries = readdirSync(sessionDir, { withFileTypes: true })
+    const sessionFiles: string[] = []
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const sessionFile = join(sessionDir, entry.name, "session.json")
+        if (existsSync(sessionFile)) {
+          sessionFiles.push(sessionFile)
+        }
+      }
+    }
+
+    return sessionFiles
+      .map((filePath) => {
+        try {
+          const content = JSON.parse(readFileSync(filePath, "utf-8"))
+          const stat = statSync(filePath)
+          return {
+            ...content,
+            sessionFile: filePath,
+            lastModified: stat.mtime
+          }
+        } catch {
+          return null
+        }
+      })
+      .filter((session): session is Session => {
+        if (!session || !session.pid) return false
+        try {
+          process.kill(session.pid, 0)
+          return true
+        } catch {
+          return false
+        }
+      })
+      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Find the active session for the current working directory.
+ * Falls back to the most recent session if no exact match is found.
+ */
+export function findCurrentSession(): Session | null {
+  const sessions = findActiveSessions()
+  if (sessions.length === 0) return null
+
+  const currentProject = getProjectName()
+  return sessions.find((s) => s.projectName === currentProject) || sessions[0]
+}


### PR DESCRIPTION
## Summary

Updates AGENTS.md and both SKILL.md files to remove manual `--cdp $(d3k cdp-port)` boilerplate from all examples.

With #103, `d3k agent-browser` auto-connects to the session's CDP port before running the user's command. The docs now reflect this:

```bash
# Before (5 commands, each with --cdp boilerplate)
CDP_PORT="$(d3k cdp-port)"
d3k agent-browser --cdp "$CDP_PORT" open http://localhost:3000
d3k agent-browser --cdp "$CDP_PORT" snapshot -i
d3k agent-browser --cdp "$CDP_PORT" click @e2

# After (just works)
d3k agent-browser open http://localhost:3000
d3k agent-browser snapshot -i
d3k agent-browser click @e2
```

## Files changed

- `AGENTS.md` — remove CDP_PORT variable, simplify browser examples
- `src/skills/d3k/SKILL.md` — update Browser Interaction, Fix Workflow, Screenshots sections
- `skills/d3k/SKILL.md` — update CDP Browser Control and Examples sections

Depends on #103.