### PR TITLE
fix: make mcp config writes idempotent

### DIFF
--- a/src/dev-environment.ts
+++ b/src/dev-environment.ts
@@ -22,16 +22,14 @@ import { CDPMonitor } from "./cdp-monitor.js"
 import { ScreencastManager } from "./screencast-manager.js"
 import { type LogEntry, NextJsErrorDetector, OutputProcessor, StandardLogParser } from "./services/parsers/index.js"
 import { DevTUI } from "./tui-interface.js"
-import { formatMcpConfigTargets, MCP_CONFIG_TARGETS, type McpConfigTarget } from "./utils/mcp-configs.js"
+import {
+  formatMcpConfigTargets,
+  MCP_CONFIG_TARGETS,
+  type McpConfigTarget,
+  upsertMcpServerConfig
+} from "./utils/mcp-configs.js"
 import { getProjectDisplayName, getProjectName } from "./utils/project-name.js"
 import { formatTimestamp } from "./utils/timestamp.js"
-
-// MCP names
-const MCP_NAMES = {
-  DEV3000: "dev3000",
-  CHROME_DEVTOOLS: "dev3000-chrome-devtools",
-  NEXTJS_DEV: "dev3000-nextjs-dev"
-} as const
 
 interface DevEnvironmentOptions {
   port: string
@@ -212,31 +210,10 @@ async function ensureMcpServers(mcpPort: string, _appPort: string, _enableChrome
       settings = {}
     }
 
-    // Ensure mcpServers structure exists
-    if (!settings.mcpServers) {
-      settings.mcpServers = {}
-    }
+    const result = upsertMcpServerConfig(settings, "claude", mcpPort)
 
-    let added = false
-
-    // Add dev3000 MCP server (HTTP type)
-    // NOTE: dev3000 now acts as an MCP orchestrator/gateway that internally
-    // spawns and connects to chrome-devtools-mcp and next-devtools-mcp as stdio processes,
-    // so users only need to configure dev3000 once!
-    if (!settings.mcpServers[MCP_NAMES.DEV3000]) {
-      settings.mcpServers[MCP_NAMES.DEV3000] = {
-        type: "http",
-        url: `http://localhost:${mcpPort}/mcp`
-      }
-      added = true
-    }
-
-    // REMOVED: No longer auto-configure chrome-devtools and nextjs-dev
-    // dev3000 MCP server now orchestrates these internally via the gateway pattern
-
-    // Write if we added anything
-    if (added) {
-      writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8")
+    if (result.changed) {
+      writeFileSync(settingsPath, `${JSON.stringify(result.config, null, 2)}\n`, "utf-8")
     }
   } catch (_error) {
     // Ignore errors - settings file manipulation is optional
@@ -272,30 +249,10 @@ async function ensureCursorMcpServers(
       settings = {}
     }
 
-    // Ensure mcpServers structure exists
-    if (!settings.mcpServers) {
-      settings.mcpServers = {}
-    }
+    const result = upsertMcpServerConfig(settings, "cursor", mcpPort)
 
-    let added = false
-
-    // Add dev3000 MCP server
-    // NOTE: dev3000 now acts as an MCP orchestrator/gateway that internally
-    // spawns and connects to chrome-devtools-mcp and next-devtools-mcp as stdio processes
-    if (!settings.mcpServers[MCP_NAMES.DEV3000]) {
-      settings.mcpServers[MCP_NAMES.DEV3000] = {
-        type: "http",
-        url: `http://localhost:${mcpPort}/mcp`
-      }
-      added = true
-    }
-
-    // REMOVED: No longer auto-configure chrome-devtools and nextjs-dev
-    // dev3000 MCP server now orchestrates these internally via the gateway pattern
-
-    // Write if we added anything
-    if (added) {
-      writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8")
+    if (result.changed) {
+      writeFileSync(settingsPath, `${JSON.stringify(result.config, null, 2)}\n`, "utf-8")
     }
   } catch (_error) {
     // Ignore errors - settings file manipulation is optional
@@ -333,31 +290,10 @@ async function ensureOpenCodeMcpServers(
       settings = {}
     }
 
-    // Ensure mcp structure exists
-    if (!settings.mcp) {
-      settings.mcp = {}
-    }
+    const result = upsertMcpServerConfig(settings, "opencode", mcpPort)
 
-    let added = false
-
-    // Add dev3000 MCP server - use npx with mcp-client to connect to HTTP server
-    // NOTE: dev3000 now acts as an MCP orchestrator/gateway that internally
-    // spawns and connects to chrome-devtools-mcp and next-devtools-mcp as stdio processes
-    if (!settings.mcp[MCP_NAMES.DEV3000]) {
-      settings.mcp[MCP_NAMES.DEV3000] = {
-        type: "remote",
-        url: `http://localhost:${mcpPort}/mcp`,
-        enabled: true
-      }
-      added = true
-    }
-
-    // REMOVED: No longer auto-configure chrome-devtools and nextjs-dev
-    // dev3000 MCP server now orchestrates these internally via the gateway pattern
-
-    // Write if we added anything
-    if (added) {
-      writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8")
+    if (result.changed) {
+      writeFileSync(settingsPath, `${JSON.stringify(result.config, null, 2)}\n`, "utf-8")
     }
   } catch (_error) {
     // Ignore errors - settings file manipulation is optional

--- a/src/utils/mcp-configs.test.ts
+++ b/src/utils/mcp-configs.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { formatMcpConfigTargets, MCP_CONFIG_TARGETS, parseDisabledMcpConfigs } from "./mcp-configs.js"
+import {
+  formatMcpConfigTargets,
+  MCP_CONFIG_TARGETS,
+  parseDisabledMcpConfigs,
+  upsertMcpServerConfig
+} from "./mcp-configs.js"
 
 describe("parseDisabledMcpConfigs", () => {
   it("returns an empty array when input is undefined", () => {
@@ -30,5 +35,75 @@ describe("formatMcpConfigTargets", () => {
 
   it("returns an empty string when no targets are provided", () => {
     expect(formatMcpConfigTargets([])).toBe("")
+  })
+})
+
+describe("upsertMcpServerConfig", () => {
+  it("updates stale dev3000 URLs while preserving existing config", () => {
+    const result = upsertMcpServerConfig(
+      {
+        mcpServers: {
+          existing: { type: "stdio", command: "existing-tool" },
+          dev3000: { type: "http", url: "http://localhost:3684/mcp" }
+        },
+        note: "keep me"
+      },
+      "claude",
+      "3999"
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.config).toEqual({
+      mcpServers: {
+        existing: { type: "stdio", command: "existing-tool" },
+        dev3000: { type: "http", url: "http://localhost:3999/mcp" }
+      },
+      note: "keep me"
+    })
+  })
+
+  it("reports unchanged when the dev3000 URL already matches", () => {
+    const existingConfig = {
+      mcpServers: {
+        dev3000: { type: "http", url: "http://localhost:3684/mcp" }
+      }
+    }
+
+    const result = upsertMcpServerConfig(existingConfig, "claude", "3684")
+
+    expect(result.changed).toBe(false)
+    expect(result.config).toEqual(existingConfig)
+  })
+
+  it("updates OpenCode URLs without re-enabling a disabled entry", () => {
+    const result = upsertMcpServerConfig(
+      {
+        mcp: {
+          dev3000: { type: "remote", url: "http://localhost:3684/mcp", enabled: false }
+        }
+      },
+      "opencode",
+      "3999"
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.config).toEqual({
+      mcp: {
+        dev3000: { type: "remote", url: "http://localhost:3999/mcp", enabled: false }
+      }
+    })
+  })
+
+  it("does not overwrite a custom dev3000 server entry", () => {
+    const existingConfig = {
+      mcpServers: {
+        dev3000: { type: "stdio", command: "custom-dev3000" }
+      }
+    }
+
+    const result = upsertMcpServerConfig(existingConfig, "claude", "3999")
+
+    expect(result.changed).toBe(false)
+    expect(result.config).toEqual(existingConfig)
   })
 })

--- a/src/utils/mcp-configs.ts
+++ b/src/utils/mcp-configs.ts
@@ -1,5 +1,7 @@
 export type McpConfigTarget = "claude" | "cursor" | "opencode"
 
+const DEV3000_MCP_SERVER_NAME = "dev3000"
+
 export const MCP_CONFIG_TARGETS: readonly McpConfigTarget[] = ["claude", "cursor", "opencode"] as const
 
 export const MCP_CONFIG_DISPLAY_NAMES: Record<McpConfigTarget, string> = {
@@ -23,6 +25,38 @@ const MCP_CONFIG_ALIASES: Record<string, McpConfigTarget> = {
 
 function normalizeToken(value: string): string {
   return value.trim().toLowerCase()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function getConfigKey(target: McpConfigTarget): "mcp" | "mcpServers" {
+  return target === "opencode" ? "mcp" : "mcpServers"
+}
+
+function isManagedDev3000Server(value: Record<string, unknown>): boolean {
+  return typeof value.url === "string" && /^http:\/\/localhost:\d+\/mcp$/.test(value.url)
+}
+
+function getServerConfig(target: McpConfigTarget, mcpPort: string, existing?: Record<string, unknown>) {
+  const url = `http://localhost:${mcpPort}/mcp`
+  const current = existing ?? {}
+
+  if (target === "opencode") {
+    return {
+      ...current,
+      type: "remote",
+      url,
+      enabled: typeof existing?.enabled === "boolean" ? existing.enabled : true
+    }
+  }
+
+  return {
+    ...current,
+    type: "http",
+    url
+  }
 }
 
 export function parseDisabledMcpConfigs(input?: string | null): McpConfigTarget[] {
@@ -64,4 +98,45 @@ export function formatMcpConfigTargets(targets: McpConfigTarget[]): string {
   }
 
   return targets.map((target) => MCP_CONFIG_DISPLAY_NAMES[target]).join(", ")
+}
+
+export function upsertMcpServerConfig(
+  config: Record<string, unknown>,
+  target: McpConfigTarget,
+  mcpPort: string
+): { config: Record<string, unknown>; changed: boolean } {
+  const configKey = getConfigKey(target)
+  const existingServers = config[configKey]
+
+  if (existingServers !== undefined && !isRecord(existingServers)) {
+    return { config, changed: false }
+  }
+
+  const servers: Record<string, unknown> = existingServers ? { ...existingServers } : {}
+  const existingServer = servers[DEV3000_MCP_SERVER_NAME]
+  const existingServerRecord = isRecord(existingServer) ? existingServer : undefined
+
+  if (existingServer !== undefined && !existingServerRecord) {
+    return { config, changed: false }
+  }
+
+  if (existingServerRecord && !isManagedDev3000Server(existingServerRecord)) {
+    return { config, changed: false }
+  }
+
+  const nextServer = getServerConfig(target, mcpPort, existingServerRecord)
+
+  if (existingServerRecord && JSON.stringify(existingServerRecord) === JSON.stringify(nextServer)) {
+    return { config, changed: false }
+  }
+
+  servers[DEV3000_MCP_SERVER_NAME] = nextServer
+
+  return {
+    config: {
+      ...config,
+      [configKey]: servers
+    },
+    changed: true
+  }
 }


### PR DESCRIPTION
## Summary

This PR makes dev3000’s automatic MCP config updates idempotent and safer when config files already contain a `dev3000` entry.

- Add a shared `upsertMcpServerConfig` helper for Claude, Cursor, and OpenCode config shapes
- Update stale dev3000 localhost MCP URLs when the MCP port changes
- Avoid rewriting config files when the dev3000 entry is already up to date
- Preserve existing MCP servers and top-level config fields
- Preserve OpenCode `enabled: false`
- Avoid overwriting custom user-managed `dev3000` entries

## Why

dev3000 keeps MCP client config files around between runs. If the MCP port changes, an existing `dev3000` entry can point at a stale localhost URL, while repeated runs should not rewrite files that are already current.

This keeps the auto-config behavior useful while making the write path more conservative and predictable.

## Tests

- `pnpm.cmd test src\utils\mcp-configs.test.ts`
- `pnpm.cmd exec tsc --noEmit --pretty false`
- `pnpm.cmd exec biome check src\dev-environment.ts src\utils\mcp-configs.ts src\utils\mcp-configs.test.ts`
- `git diff --check`