### PR TITLE
Add Linux ARM64 platform binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
         run: npm publish --provenance --access public
         working-directory: packages/d3k-linux-x64
 
+      - name: Publish @d3k/linux-arm64 to npm
+        run: npm publish --provenance --access public
+        working-directory: packages/d3k-linux-arm64
+
       - name: Publish @d3k/windows-x64 to npm
         run: npm publish --provenance --access public
         working-directory: packages/d3k-windows-x64
@@ -176,6 +180,7 @@ jobs:
             const packagePaths = [
               'packages/d3k-darwin-arm64/package.json',
               'packages/d3k-linux-x64/package.json',
+              'packages/d3k-linux-arm64/package.json',
               'packages/d3k-windows-x64/package.json'
             ];
 
@@ -189,6 +194,7 @@ jobs:
             rootPkg.optionalDependencies = rootPkg.optionalDependencies || {};
             rootPkg.optionalDependencies['@d3k/darwin-arm64'] = nextVersion;
             rootPkg.optionalDependencies['@d3k/linux-x64'] = nextVersion;
+            rootPkg.optionalDependencies['@d3k/linux-arm64'] = nextVersion;
             rootPkg.optionalDependencies['@d3k/windows-x64'] = nextVersion;
             fs.writeFileSync('package.json', JSON.stringify(rootPkg, null, 2) + '\\n');
           "
@@ -199,6 +205,7 @@ jobs:
             const platformPackages = [
               "@d3k/darwin-arm64",
               "@d3k/linux-x64",
+              "@d3k/linux-arm64",
               "@d3k/windows-x64"
             ];
             const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -225,6 +232,6 @@ jobs:
 
       - name: Commit and push next canary
         run: |
-          git add package.json packages/d3k-darwin-arm64/package.json packages/d3k-linux-x64/package.json packages/d3k-windows-x64/package.json bun.lock
+          git add package.json packages/d3k-darwin-arm64/package.json packages/d3k-linux-x64/package.json packages/d3k-linux-arm64/package.json packages/d3k-windows-x64/package.json bun.lock
           git commit -m "Bump to v$NEXT_CANARY_VERSION for local development"
           git push origin HEAD:main

--- a/bin/dev3000
+++ b/bin/dev3000
@@ -21,9 +21,9 @@ const require = createRequire(import.meta.url)
 const PLATFORMS = {
   "darwin-arm64": "@d3k/darwin-arm64",
   "linux-x64": "@d3k/linux-x64",
+  "linux-arm64": "@d3k/linux-arm64",
   "win32-x64": "@d3k/windows-x64",
   // "darwin-x64": "@d3k/darwin-x64",  // Add later
-  // "linux-arm64": "@d3k/linux-arm64", // Add later
 }
 
 function findBinary() {
@@ -32,7 +32,7 @@ function findBinary() {
 
   if (!pkgName) {
     console.error(`\n  Unsupported platform: ${key}`)
-    console.error(`  Currently supported platforms: macOS ARM64 (Apple Silicon), Linux x64, Windows x64`)
+    console.error(`  Currently supported platforms: macOS ARM64 (Apple Silicon), Linux x64, Linux ARM64, Windows x64`)
     console.error(`\n  For other platforms, please open an issue at:`)
     console.error(`  https://github.com/vercel-labs/dev3000/issues\n`)
     process.exit(1)

--- a/bun.lock
+++ b/bun.lock
@@ -31,8 +31,10 @@
       "optionalDependencies": {
         "@d3k/darwin-arm64": "0.0.178-canary",
         "@d3k/linux-x64": "0.0.178-canary",
+        "@d3k/linux-arm64": "0.0.178-canary",
         "@d3k/windows-x64": "0.0.178-canary",
         "@opentui/core-linux-x64": "0.1.86",
+        "@opentui/core-linux-arm64": "0.1.86",
       },
     },
     "www": {

--- a/package.json
+++ b/package.json
@@ -70,8 +70,10 @@
   "optionalDependencies": {
     "@d3k/darwin-arm64": "0.0.178-canary",
     "@d3k/linux-x64": "0.0.178-canary",
+    "@d3k/linux-arm64": "0.0.178-canary",
     "@d3k/windows-x64": "0.0.178-canary",
-    "@opentui/core-linux-x64": "0.1.86"
+    "@opentui/core-linux-x64": "0.1.86",
+    "@opentui/core-linux-arm64": "0.1.86"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/d3k-linux-arm64/bunfig.toml
+++ b/packages/d3k-linux-arm64/bunfig.toml
@@ -1,0 +1,14 @@
+[install]
+# 2 days. Company-wide standard.
+minimumReleaseAge = 172800
+# Bun requires exact package names here; scope globs are not supported.
+minimumReleaseAgeExcludes = [
+  "@vercel/analytics",
+  "@vercel/blob",
+  "@vercel/oidc",
+  "@vercel/sandbox",
+  "@vercel/sdk",
+  "@vercel/speed-insights",
+  "@workflow/world-vercel",
+  "turbo",
+]

--- a/packages/d3k-linux-arm64/package.json
+++ b/packages/d3k-linux-arm64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@d3k/linux-arm64",
+  "version": "0.0.178-canary",
+  "description": "d3k binary for Linux ARM64",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "bin": {
+    "dev3000": "./bin/dev3000"
+  },
+  "scripts": {
+    "postinstall": "chmod +x mcp-server/node_modules/.bin/* 2>/dev/null || true"
+  },
+  "files": [
+    "bin/",
+    "mcp-server/",
+    "skills/",
+    "src/"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel-labs/dev3000.git"
+  },
+  "author": "Lindsey Simon <lindsey@vercel.com>",
+  "license": "MIT"
+}

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -31,6 +31,7 @@ function getBinaryVersion(version: string): string {
 const TARGETS = [
   { os: "darwin", arch: "arm64", name: "d3k-darwin-arm64" },
   { os: "linux", arch: "x64", name: "d3k-linux-x64" },
+  { os: "linux", arch: "arm64", name: "d3k-linux-arm64" },
   { os: "windows", arch: "x64", name: "d3k-windows-x64" }
 ] as const
 

--- a/scripts/canary-smoke-test.ts
+++ b/scripts/canary-smoke-test.ts
@@ -12,9 +12,11 @@ const target =
     ? "d3k-darwin-arm64"
     : platform === "linux" && arch === "x64"
       ? "d3k-linux-x64"
-      : platform === "win32" && arch === "x64"
-        ? "d3k-windows-x64"
-        : null
+      : platform === "linux" && arch === "arm64"
+        ? "d3k-linux-arm64"
+        : platform === "win32" && arch === "x64"
+          ? "d3k-windows-x64"
+          : null
 
 if (!target) {
   console.error(`Unsupported platform for canary smoke test: ${platform}-${arch}`)

--- a/scripts/canary.sh
+++ b/scripts/canary.sh
@@ -47,6 +47,16 @@ if has_target "linux-x64"; then
   cp -r "$LINUX_X64_DIST_DIR/src" "$LINUX_X64_PKG_DIR/"
 fi
 
+# linux-arm64
+LINUX_ARM64_PKG_DIR="$ROOT_DIR/packages/d3k-linux-arm64"
+LINUX_ARM64_DIST_DIR="$ROOT_DIR/dist-bin/d3k-linux-arm64"
+if has_target "linux-arm64"; then
+  rm -rf "$LINUX_ARM64_PKG_DIR/bin" "$LINUX_ARM64_PKG_DIR/skills" "$LINUX_ARM64_PKG_DIR/src"
+  cp -r "$LINUX_ARM64_DIST_DIR/bin" "$LINUX_ARM64_PKG_DIR/"
+  cp -r "$LINUX_ARM64_DIST_DIR/skills" "$LINUX_ARM64_PKG_DIR/"
+  cp -r "$LINUX_ARM64_DIST_DIR/src" "$LINUX_ARM64_PKG_DIR/"
+fi
+
 # windows-x64
 WINDOWS_X64_PKG_DIR="$ROOT_DIR/packages/d3k-windows-x64"
 WINDOWS_X64_DIST_DIR="$ROOT_DIR/dist-bin/d3k-windows-x64"

--- a/scripts/prepare-platform-packages.sh
+++ b/scripts/prepare-platform-packages.sh
@@ -25,6 +25,13 @@ cp -r "$LINUX_X64_DIST_DIR/bin" "$LINUX_X64_PKG_DIR/"
 cp -r "$LINUX_X64_DIST_DIR/skills" "$LINUX_X64_PKG_DIR/"
 cp -r "$LINUX_X64_DIST_DIR/src" "$LINUX_X64_PKG_DIR/"
 
+LINUX_ARM64_PKG_DIR="packages/d3k-linux-arm64"
+LINUX_ARM64_DIST_DIR="dist-bin/d3k-linux-arm64"
+rm -rf "$LINUX_ARM64_PKG_DIR/bin" "$LINUX_ARM64_PKG_DIR/skills" "$LINUX_ARM64_PKG_DIR/src"
+cp -r "$LINUX_ARM64_DIST_DIR/bin" "$LINUX_ARM64_PKG_DIR/"
+cp -r "$LINUX_ARM64_DIST_DIR/skills" "$LINUX_ARM64_PKG_DIR/"
+cp -r "$LINUX_ARM64_DIST_DIR/src" "$LINUX_ARM64_PKG_DIR/"
+
 WINDOWS_X64_PKG_DIR="packages/d3k-windows-x64"
 WINDOWS_X64_DIST_DIR="dist-bin/d3k-windows-x64"
 rm -rf "$WINDOWS_X64_PKG_DIR/bin" "$WINDOWS_X64_PKG_DIR/skills" "$WINDOWS_X64_PKG_DIR/src"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,7 @@ node -e "
     pkg.optionalDependencies = pkg.optionalDependencies || {};
     pkg.optionalDependencies['@d3k/darwin-arm64'] = '$NEXT_VERSION';
     pkg.optionalDependencies['@d3k/linux-x64'] = '$NEXT_VERSION';
+    pkg.optionalDependencies['@d3k/linux-arm64'] = '$NEXT_VERSION';
     pkg.optionalDependencies['@d3k/windows-x64'] = '$NEXT_VERSION';
     fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
@@ -57,7 +58,7 @@ node -e "
 echo "⬆️ Updating platform package versions to $NEXT_VERSION..."
 node -e "
     const fs = require('fs');
-    ['packages/d3k-darwin-arm64/package.json', 'packages/d3k-linux-x64/package.json', 'packages/d3k-windows-x64/package.json'].forEach(pkgPath => {
+    ['packages/d3k-darwin-arm64/package.json', 'packages/d3k-linux-x64/package.json', 'packages/d3k-linux-arm64/package.json', 'packages/d3k-windows-x64/package.json'].forEach(pkgPath => {
         const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
         pkg.version = '$NEXT_VERSION';
         fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
@@ -89,6 +90,16 @@ node -e "
     lockfile = lockfile.replace(
         /'@d3k\/linux-x64@[^']+'/g,
         \"'@d3k/linux-x64@$NEXT_VERSION'\"
+    );
+
+    // Update linux-arm64
+    lockfile = lockfile.replace(
+        /('@d3k\/linux-arm64':\n\s+specifier: )[^\n]+(\n\s+version: )[^\n]+/,
+        \"\\\$1$NEXT_VERSION\\\$2$NEXT_VERSION\"
+    );
+    lockfile = lockfile.replace(
+        /'@d3k\/linux-arm64@[^']+'/g,
+        \"'@d3k/linux-arm64@$NEXT_VERSION'\"
     );
 
     // Update windows-x64
@@ -143,7 +154,7 @@ bun scripts/generate-changelog-md.ts
 
 # Commit version change and changelog
 echo "📝 Committing version change and changelog..."
-git add package.json packages/d3k-darwin-arm64/package.json packages/d3k-linux-x64/package.json packages/d3k-windows-x64/package.json www/package.json www/lib/changelog.ts CHANGELOG.md bun.lock
+git add package.json packages/d3k-darwin-arm64/package.json packages/d3k-linux-x64/package.json packages/d3k-linux-arm64/package.json packages/d3k-windows-x64/package.json www/package.json www/lib/changelog.ts CHANGELOG.md bun.lock
 git commit -m "Release v$NEXT_VERSION
 
 🤖 Generated with [Claude Code](https://claude.ai/code)


### PR DESCRIPTION
## Summary

Adds a `linux-arm64` build target and `@d3k/linux-arm64` platform package, mirroring the existing `darwin-arm64` / `linux-x64` / `windows-x64` packages, so d3k installs and runs on Linux ARM64.

This makes it possible to run d3k inside native-arm64 VS Code devcontainers on Apple Silicon Macs.

## Changes

- Add `{ os: "linux", arch: "arm64" }` to the binary build matrix (`scripts/build-binaries.ts`)
- Register `linux-arm64 → @d3k/linux-arm64` in the platform wrapper (`bin/dev3000`)
- Add the `@d3k/linux-arm64` platform package and wire it into `optionalDependencies` + `bun.lock`
- Extend the canary/release scripts and release workflow to build and publish the new package

## Test plan

- [x] Lint passes
- [x] TypeScript passes
- [x] Tests pass
- [x] Cross-compiled `bun-linux-arm64` binary runs in a native `linux/arm64` container (`--version` / `--help`)
