### PR TITLE
Doc: fixed the link to the release version on GitHub

### DIFF
--- a/www/app/changelog/[version]/page.tsx
+++ b/www/app/changelog/[version]/page.tsx
@@ -165,7 +165,7 @@ export default async function VersionPage({ params }: { params: Promise<{ versio
         {/* Footer Actions */}
         <div className="mt-8 pt-6 border-t flex items-center justify-between">
           <Link
-            href={`https://github.com/elsigh/dev3000/releases/tag/v${release.version}`}
+            href={`https://github.com/vercel-labs/dev3000/releases/tag/v${release.version}`}
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Hi,

The link on the [changelog/[version]/page.tsx](https://dev3000.ai/changelog/v0.0.177) page does not redirect to the correct repository (elsigh instead of vercel-labs)
