### PR TITLE
perf: upgrade agent-browser and stream d3k telemetry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "dev3000",
       "dependencies": {
         "@opentui/core": "0.5.8",
-        "agent-browser": "0.34.0",
+        "agent-browser": "0.36.0",
         "chalk": "^6.0.0",
         "commander": "15.0.0",
         "ink": "7.1.1",
@@ -901,7 +901,7 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "agent-browser": ["agent-browser@0.34.0", "", { "bin": { "agent-browser": "./bin/agent-browser.js" } }, "sha512-eR6Ey4I/DMs9zZ60b3ziV6pgLIgpxXWzggr3dfFbtskLmeXPJAgXCIIwVL4PihVYJqEUpvWgUKlZ2CIjY1u44g=="],
+    "agent-browser": ["agent-browser@0.36.0", "", { "bin": { "agent-browser": "./bin/agent-browser.js" } }, "sha512-Ljjj4nRKUEqtrFF0pgev8lxTfC79tNgPj67sNi6BLnUAWIG8y9Cu2VQIeZ0MY3N2fTQagoBlfQ/pUY/4NWPD3w=="],
 
     "ai": ["ai@7.0.77", "", { "dependencies": { "@ai-sdk/gateway": "4.0.62", "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.29" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-muLtBSTAUCreR77L16w4AFBiX2gK/RNt84EKp8m03SN9+MfNlC5EGqYYttRjYKV3xe0a33yj1Zawj1EnjejIWw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@types/ws": "^8.18.1",
         "@typescript/native": "npm:typescript@^7.0.2",
         "husky": "^9.1.7",
+        "react-devtools-core": "7.0.1",
         "tsx": "^4.23.12",
         "typescript": "^7.0.2",
         "vitest": "4.1.11",
@@ -1575,6 +1576,8 @@
 
     "react-day-picker": ["react-day-picker@10.0.1", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "date-fns": "^4.1.0" }, "peerDependencies": { "@types/react": ">=16.8.0", "react": ">=16.8.0" }, "optionalPeers": ["@types/react"] }, "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "react-hook-form": ["react-hook-form@7.86.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-4kbWJrh5jPZt1+YqVcXcGKffGcXV/XVbozknLh0Yjh0KhpoAkus21TAQhzRYqNwFkkObmnSvRlZZ3GT+ehoIrA=="],
@@ -1662,6 +1665,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "shiki": ["shiki@4.4.3", "", { "dependencies": { "@shikijs/core": "4.4.3", "@shikijs/engine-javascript": "4.4.3", "@shikijs/engine-oniguruma": "4.4.3", "@shikijs/langs": "4.4.3", "@shikijs/themes": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g=="],
 
@@ -2098,6 +2103,8 @@
     "ora/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
+
+    "react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "@opentui/core": "0.5.8",
-    "agent-browser": "0.34.0",
+    "agent-browser": "0.36.0",
     "chalk": "^6.0.0",
     "commander": "15.0.0",
     "ink": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/react": "19.2.18",
     "@types/ws": "^8.18.1",
     "husky": "^9.1.7",
+    "react-devtools-core": "7.0.1",
     "tsx": "^4.23.12",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^7.0.2",

--- a/src/cdp-monitor.test.ts
+++ b/src/cdp-monitor.test.ts
@@ -6,10 +6,82 @@ import {
   CDPMonitor,
   type CDPTargetInfo,
   CHROME_CRASH_RESTORE_SUPPRESSION_FLAGS,
+  DEV3000_CDP_BINDING_NAME,
   getLoadingHtmlCandidates,
+  parseDev3000TelemetryPayload,
   resetChromeCrashRestoreState,
   selectCDPTarget
 } from "./cdp-monitor"
+
+describe("d3k CDP telemetry binding", () => {
+  it("parses interaction events without trusting arbitrary payloads", () => {
+    const payload = JSON.stringify({
+      kind: "interaction",
+      interaction: { timestamp: 123, message: "CLICK at 10,20 on button" }
+    })
+
+    expect(DEV3000_CDP_BINDING_NAME).toBe("__dev3000_emit")
+    expect(parseDev3000TelemetryPayload(payload)).toEqual({
+      kind: "interaction",
+      interaction: { timestamp: 123, message: "CLICK at 10,20 on button" }
+    })
+  })
+
+  it("parses React telemetry state and rejects malformed events", () => {
+    expect(
+      parseDev3000TelemetryPayload(
+        JSON.stringify({
+          kind: "react",
+          event: { timestamp: 456, type: "operations-first" },
+          state: { rendererVersion: "19.1.0", bundleType: 1, operationsSeen: 1 }
+        })
+      )
+    ).toEqual({
+      kind: "react",
+      event: { timestamp: 456, type: "operations-first" },
+      state: { rendererVersion: "19.1.0", bundleType: 1, operationsSeen: 1 }
+    })
+
+    expect(parseDev3000TelemetryPayload("not-json")).toBeNull()
+    expect(parseDev3000TelemetryPayload(JSON.stringify({ kind: "interaction", interaction: {} }))).toBeNull()
+    expect(parseDev3000TelemetryPayload(JSON.stringify({ kind: "unknown" }))).toBeNull()
+  })
+
+  it("does not start the compatibility polling loop when the binding is active", async () => {
+    const monitor = new CDPMonitor("/tmp/d3k-profile", "/tmp/d3k-screenshots", () => {})
+    const sendCDPCommand = vi.fn()
+    Object.assign(monitor as unknown as Record<string, unknown>, {
+      interactionBindingAvailable: true,
+      sendCDPCommand
+    })
+
+    ;(monitor as unknown as { startInteractionPolling: () => void }).startInteractionPolling()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(sendCDPCommand).not.toHaveBeenCalled()
+  })
+
+  it("routes binding events through the existing browser log path", () => {
+    const logs: string[] = []
+    const monitor = new CDPMonitor("/tmp/d3k-profile", "/tmp/d3k-screenshots", (_source, message) => {
+      logs.push(message)
+    })
+
+    ;(monitor as unknown as { setupEventHandlers: () => void }).setupEventHandlers()
+    ;(monitor as unknown as { handleCDPMessage: (message: unknown) => void }).handleCDPMessage({
+      method: "Runtime.bindingCalled",
+      params: {
+        name: DEV3000_CDP_BINDING_NAME,
+        payload: JSON.stringify({
+          kind: "interaction",
+          interaction: { timestamp: 123, message: "CLICK at 10,20 on button" }
+        })
+      }
+    })
+
+    expect(logs).toContain("[INTERACTION] CLICK at 10,20 on button")
+  })
+})
 
 describe("selectCDPTarget", () => {
   it("prefers the current app target when Chrome exposes multiple pages", () => {

--- a/src/cdp-monitor.ts
+++ b/src/cdp-monitor.ts
@@ -43,6 +43,32 @@ interface ReactDebugSnapshot {
   operationsSeen: number
 }
 
+interface Dev3000InteractionTelemetry {
+  kind: "interaction"
+  interaction: {
+    timestamp: number
+    message: string
+  }
+}
+
+interface Dev3000ReactTelemetry {
+  kind: "react"
+  event: {
+    timestamp: number
+    type: string
+    rendererVersion?: string | null
+    bundleType?: number | null
+  }
+  state: {
+    connected?: boolean
+    rendererVersion?: string | null
+    bundleType?: number | null
+    operationsSeen?: number
+  }
+}
+
+type Dev3000Telemetry = Dev3000InteractionTelemetry | Dev3000ReactTelemetry
+
 const EMBEDDED_LOADING_HTML = `<!DOCTYPE html>
 <html>
 <head>
@@ -85,6 +111,7 @@ const EMBEDDED_LOADING_HTML = `<!DOCTYPE html>
 
 const DEFAULT_CDP_COMMAND_TIMEOUT_MS = 10000
 const DEFAULT_NAVIGATION_TIMEOUT_MS = 60000
+export const DEV3000_CDP_BINDING_NAME = "__dev3000_emit"
 export const CHROME_CRASH_RESTORE_SUPPRESSION_FLAGS = [
   "--disable-session-crashed-bubble",
   "--disable-restore-session-state",
@@ -93,6 +120,51 @@ export const CHROME_CRASH_RESTORE_SUPPRESSION_FLAGS = [
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function parseDev3000TelemetryPayload(payload: string): Dev3000Telemetry | null {
+  try {
+    const value: unknown = JSON.parse(payload)
+    if (!isRecord(value) || (value.kind !== "interaction" && value.kind !== "react")) {
+      return null
+    }
+
+    if (value.kind === "interaction") {
+      if (!isRecord(value.interaction)) return null
+      const { timestamp, message } = value.interaction
+      if (typeof timestamp !== "number" || typeof message !== "string") return null
+      return { kind: "interaction", interaction: { timestamp, message } }
+    }
+
+    if (!isRecord(value.event) || !isRecord(value.state)) return null
+    const { timestamp, type, rendererVersion, bundleType } = value.event
+    if (typeof timestamp !== "number" || typeof type !== "string") return null
+    if (rendererVersion !== undefined && rendererVersion !== null && typeof rendererVersion !== "string") {
+      return null
+    }
+    if (bundleType !== undefined && bundleType !== null && typeof bundleType !== "number") {
+      return null
+    }
+
+    return {
+      kind: "react",
+      event: { timestamp, type, rendererVersion, bundleType },
+      state: {
+        connected: typeof value.state.connected === "boolean" ? value.state.connected : undefined,
+        rendererVersion:
+          typeof value.state.rendererVersion === "string" || value.state.rendererVersion === null
+            ? value.state.rendererVersion
+            : undefined,
+        bundleType:
+          typeof value.state.bundleType === "number" || value.state.bundleType === null
+            ? value.state.bundleType
+            : undefined,
+        operationsSeen: typeof value.state.operationsSeen === "number" ? value.state.operationsSeen : undefined
+      }
+    }
+  } catch {
+    return null
+  }
 }
 
 function patchChromePreferences(data: Record<string, unknown>): boolean {
@@ -337,6 +409,7 @@ export class CDPMonitor {
   private headless: boolean = false // Run Chrome in headless mode
   private framework?: "nextjs" | "svelte" | "other" // Framework hint from project detection
   private reactTrackingEnabled: boolean = false
+  private interactionBindingAvailable = false
   private lastReactSnapshotLogTime: number = 0
   private pendingCommands = new Map<number, PendingCDPRequest>()
   private navigationTimeoutMs: number = DEFAULT_NAVIGATION_TIMEOUT_MS
@@ -976,6 +1049,7 @@ export class CDPMonitor {
               sessionId: null,
               nextId: 1
             }
+            this.interactionBindingAvailable = false
             resolve()
           })
 
@@ -1296,7 +1370,81 @@ export class CDPMonitor {
     }
   }
 
+  private async ensureInteractionBinding(): Promise<void> {
+    if (this.interactionBindingAvailable) return
+
+    try {
+      await this.sendCDPCommand("Runtime.addBinding", {
+        name: DEV3000_CDP_BINDING_NAME
+      })
+      this.interactionBindingAvailable = true
+      this.debugLog("Installed event-driven interaction telemetry binding")
+    } catch (error) {
+      // A binding survives document navigations. Chrome reports a duplicate
+      // binding as an error on later reinjections, which is still a usable
+      // binding; only fall back to polling for other failures.
+      if (String(error).toLowerCase().includes("already")) {
+        this.interactionBindingAvailable = true
+        return
+      }
+      this.debugLog(`Runtime.addBinding unavailable; using telemetry polling fallback: ${String(error)}`)
+    }
+  }
+
+  private handleInteractionTelemetry(interaction: Dev3000InteractionTelemetry["interaction"]): void {
+    this.logger("browser", `[INTERACTION] ${interaction.message}`)
+
+    if (interaction.message.startsWith("SCROLL_SETTLED")) {
+      this.takeScreenshot("scroll-settled")
+    }
+  }
+
+  private handleReactTelemetry(
+    reactEvent: Dev3000ReactTelemetry["event"],
+    reactState: Dev3000ReactTelemetry["state"]
+  ): void {
+    if (reactEvent.type === "renderer") {
+      this.logger(
+        "browser",
+        `[REACT] renderer detected: version=${reactEvent.rendererVersion || "unknown"} mode=${this.getBundleTypeLabel(reactEvent.bundleType ?? null)}`
+      )
+      return
+    }
+
+    if (reactEvent.type === "operations-first") {
+      const rendererVersion = reactState.rendererVersion || "unknown"
+      const mode = this.getBundleTypeLabel(reactState.bundleType ?? null)
+      const operationsSeen = Number(reactState.operationsSeen || 0)
+      this.logger(
+        "browser",
+        `[REACT] devtools bridge connected: renderer=${rendererVersion} mode=${mode} ops=${operationsSeen}`
+      )
+    }
+  }
+
   private setupEventHandlers(): void {
+    // Interaction and React telemetry is delivered by Runtime.bindingCalled when
+    // Chrome supports Runtime.addBinding. This avoids a permanent polling loop
+    // and leaves the old Runtime.evaluate poll as a compatibility fallback.
+    this.onCDPEvent("Runtime.bindingCalled", (event) => {
+      const params = event.params as { name?: unknown; payload?: unknown }
+      if (params.name !== DEV3000_CDP_BINDING_NAME || typeof params.payload !== "string") {
+        return
+      }
+
+      const telemetry = parseDev3000TelemetryPayload(params.payload)
+      if (!telemetry) {
+        this.debugLog("Ignoring malformed d3k CDP telemetry payload")
+        return
+      }
+
+      if (telemetry.kind === "interaction") {
+        this.handleInteractionTelemetry(telemetry.interaction)
+      } else {
+        this.handleReactTelemetry(telemetry.event, telemetry.state)
+      }
+    })
+
     // Console messages with full context
     this.onCDPEvent("Runtime.consoleAPICalled", (event) => {
       const params = event.params as {
@@ -1750,6 +1898,8 @@ export class CDPMonitor {
 
   private async setupInteractionTracking(): Promise<void> {
     try {
+      await this.ensureInteractionBinding()
+
       // First check if tracking is already set up to avoid redundant injections
       this.debugLog("About to check if tracking is already set up...")
       const checkResult = (await this.sendCDPCommand("Runtime.evaluate", {
@@ -1764,6 +1914,7 @@ export class CDPMonitor {
 
       this.debugLog("About to inject tracking script...")
       // Full interaction tracking script with element details for replay
+      const bindingNameLiteral = JSON.stringify(DEV3000_CDP_BINDING_NAME)
       const trackingScript = `
         try {
           if (!window.__dev3000_cdp_tracking) {
@@ -1917,6 +2068,22 @@ export class CDPMonitor {
             // Listen for our custom interaction events and store them for CDP polling
             window.__dev3000_interactions = [];
 
+            // Prefer the CDP binding so telemetry crosses the browser boundary
+            // only when an event occurs. The queue remains as a fallback for
+            // older or restricted CDP implementations.
+            const emitTelemetry = (value) => {
+              const binding = window[${bindingNameLiteral}];
+              if (typeof binding === 'function') {
+                try {
+                  binding(JSON.stringify(value));
+                  return true;
+                } catch (_) {
+                  // Fall through to the compatibility queue below.
+                }
+              }
+              return false;
+            };
+
             // Lightweight React bridge telemetry (no PPR-specific parsing).
             if (!window.__dev3000_react_tracking) {
               window.__dev3000_react_tracking = true;
@@ -1929,10 +2096,17 @@ export class CDPMonitor {
               };
 
               const pushReactEvent = (event) => {
-                window.__dev3000_react_events.push({
+                const eventWithTimestamp = {
                   timestamp: Date.now(),
                   ...event
-                });
+                };
+                if (emitTelemetry({
+                  kind: 'react',
+                  event: eventWithTimestamp,
+                  state: window.__dev3000_react_state
+                })) return;
+
+                window.__dev3000_react_events.push(eventWithTimestamp);
                 if (window.__dev3000_react_events.length > 50) {
                   window.__dev3000_react_events = window.__dev3000_react_events.slice(-50);
                 }
@@ -1998,11 +2172,15 @@ export class CDPMonitor {
               }
               
               if (message) {
-                // Store interaction in array for CDP to poll, don't log to console
-                window.__dev3000_interactions.push({
+                const interaction = {
                   timestamp: Date.now(),
                   message: message
-                });
+                };
+                if (emitTelemetry({ kind: 'interaction', interaction })) return;
+
+                // Store interaction in the compatibility queue when the CDP
+                // binding is unavailable; the monitor will poll this queue.
+                window.__dev3000_interactions.push(interaction);
                 
                 // Keep only last 100 interactions to avoid memory issues
                 if (window.__dev3000_interactions.length > 100) {
@@ -2058,6 +2236,11 @@ export class CDPMonitor {
   }
 
   private startInteractionPolling(): void {
+    if (this.interactionBindingAvailable) {
+      this.debugLog("Skipping interaction telemetry polling; CDP binding is active")
+      return
+    }
+
     // Poll for interactions every 500ms to avoid console.log spam
     const pollInteractions = async () => {
       if (this.isShuttingDown) return

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -188,20 +188,15 @@ function runLocalBrowserTool(args: string[]) {
     process.exit(1)
   }
 
-  if (subcommand !== "connect" && subcommand !== "close" && !hasExplicitCdp && !hasProfile) {
-    if (sessionCdpPort) {
-      const connectResult = spawnSync(binaryPath, ["connect", sessionCdpPort], { stdio: "pipe", env, shell: false })
-      if (needsD3kBrowser && connectResult.status !== 0) {
-        printUnsafeAgentBrowserOpenError(
-          "d3k found a browser session, but agent-browser could not connect to it.",
-          activeSession !== null
-        )
-        process.exit(connectResult.status ?? 1)
-      }
-    }
-  }
+  // agent-browser accepts --cdp on every command. Passing the active d3k
+  // endpoint directly avoids a second native process just to run `connect`.
+  const browserArgs = withD3kSessionCdp(toolArgs, {
+    sessionCdpPort,
+    hasExplicitCdp,
+    hasProfile
+  })
 
-  const result = spawnSync(binaryPath, toolArgs, {
+  const result = spawnSync(binaryPath, browserArgs, {
     stdio: "pipe",
     env,
     shell: false
@@ -226,7 +221,8 @@ import {
   getBrowserCommandInvocation,
   hasAgentBrowserOption,
   isAgentBrowserOpenCommand,
-  parseAgentBrowserInvocationArgs
+  parseAgentBrowserInvocationArgs,
+  withD3kSessionCdp
 } from "./utils/browser-command-argv.js"
 
 const browserCommandInvocation = getBrowserCommandInvocation(process.argv.slice(2))

--- a/src/screencast-manager.test.ts
+++ b/src/screencast-manager.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { parseDev3000LayoutShiftPayload } from "./screencast-manager"
+
+describe("d3k layout-shift telemetry binding", () => {
+  it("parses layout shifts and viewport data", () => {
+    expect(
+      parseDev3000LayoutShiftPayload(
+        JSON.stringify({
+          kind: "layout-shift",
+          shift: {
+            score: 0.125,
+            timestamp: 42,
+            sources: [
+              {
+                node: "DIV",
+                position: "relative",
+                previousRect: { x: 0, y: 0, width: 10, height: 10 },
+                currentRect: { x: 0, y: 10, width: 10, height: 10 },
+                actualRect: null
+              }
+            ]
+          },
+          viewport: { width: 1280, height: 720, devicePixelRatio: 1 }
+        })
+      )
+    ).toEqual({
+      kind: "layout-shift",
+      shift: {
+        score: 0.125,
+        timestamp: 42,
+        sources: [
+          {
+            node: "DIV",
+            position: "relative",
+            previousRect: { x: 0, y: 0, width: 10, height: 10 },
+            currentRect: { x: 0, y: 10, width: 10, height: 10 },
+            actualRect: null
+          }
+        ]
+      },
+      viewport: { width: 1280, height: 720, devicePixelRatio: 1 }
+    })
+  })
+
+  it("rejects malformed layout-shift payloads", () => {
+    expect(parseDev3000LayoutShiftPayload("not-json")).toBeNull()
+    expect(parseDev3000LayoutShiftPayload(JSON.stringify({ kind: "interaction" }))).toBeNull()
+    expect(
+      parseDev3000LayoutShiftPayload(JSON.stringify({ kind: "layout-shift", shift: { score: "bad", timestamp: 1 } }))
+    ).toBeNull()
+  })
+})

--- a/src/screencast-manager.ts
+++ b/src/screencast-manager.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { WebSocket } from "ws"
+import { DEV3000_CDP_BINDING_NAME } from "./cdp-monitor.js"
 
 export interface ScreencastFrame {
   timestamp: number // ms since navigation start
@@ -23,6 +24,73 @@ interface LayoutShiftSource {
   actualRect?: { x: number; y: number; width: number; height: number } | null
 }
 
+export interface Dev3000LayoutShiftTelemetry {
+  kind: "layout-shift"
+  shift: {
+    score: number
+    timestamp: number
+    sources?: LayoutShiftSource[]
+  }
+  viewport?: Record<string, number>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseRect(value: unknown): { x: number; y: number; width: number; height: number } | undefined {
+  if (!isRecord(value)) return undefined
+  const { x, y, width, height } = value
+  if (typeof x !== "number" || typeof y !== "number" || typeof width !== "number" || typeof height !== "number") {
+    return undefined
+  }
+  return { x, y, width, height }
+}
+
+export function parseDev3000LayoutShiftPayload(payload: string): Dev3000LayoutShiftTelemetry | null {
+  try {
+    const value: unknown = JSON.parse(payload)
+    if (!isRecord(value) || value.kind !== "layout-shift" || !isRecord(value.shift)) {
+      return null
+    }
+
+    const { score, timestamp, sources } = value.shift
+    if (typeof score !== "number" || typeof timestamp !== "number") return null
+
+    const parsedSources: LayoutShiftSource[] = []
+    if (sources !== undefined) {
+      if (!Array.isArray(sources)) return null
+      for (const source of sources) {
+        if (!isRecord(source)) return null
+        const parsedSource: LayoutShiftSource = {
+          node: typeof source.node === "string" ? source.node : undefined,
+          position: typeof source.position === "string" || source.position === null ? source.position : undefined,
+          previousRect: parseRect(source.previousRect),
+          currentRect: parseRect(source.currentRect),
+          actualRect: source.actualRect === null ? null : parseRect(source.actualRect)
+        }
+        parsedSources.push(parsedSource)
+      }
+    }
+
+    let viewport: Record<string, number> | undefined
+    if (value.viewport !== undefined) {
+      if (!isRecord(value.viewport)) return null
+      const entries = Object.entries(value.viewport)
+      if (entries.some(([, entry]) => typeof entry !== "number")) return null
+      viewport = Object.fromEntries(entries) as Record<string, number>
+    }
+
+    return {
+      kind: "layout-shift",
+      shift: { score, timestamp, sources: sources === undefined ? undefined : parsedSources },
+      viewport
+    }
+  } catch {
+    return null
+  }
+}
+
 /**
  * ScreencastManager - Passive screencast capture for navigation events
  *
@@ -31,6 +99,7 @@ interface LayoutShiftSource {
  */
 export class ScreencastManager {
   private ws: WebSocket | null = null
+  private bindingAvailable = false
   private buffer: BufferedFrame[] = []
   private isCapturing = false
   private navigationStartTime = 0
@@ -78,6 +147,7 @@ export class ScreencastManager {
         this.ws = new WebSocket(this.cdpUrl)
         let pageEnableId: number
         let runtimeEnableId: number
+        let bindingEnableId: number
         let pageEnabled = false
         let runtimeEnabled = false
 
@@ -88,12 +158,17 @@ export class ScreencastManager {
         }
 
         this.ws.on("open", () => {
+          this.bindingAvailable = false
           // Enable Page domain to receive navigation events
           pageEnableId = this.messageId++
           this.send("Page.enable", {}, pageEnableId)
           // Enable Runtime domain for URL checking
           runtimeEnableId = this.messageId++
           this.send("Runtime.enable", {}, runtimeEnableId)
+          // Prefer event-driven layout-shift telemetry over the compatibility
+          // polling loop. Binding failures do not block screencast startup.
+          bindingEnableId = this.messageId++
+          this.send("Runtime.addBinding", { name: DEV3000_CDP_BINDING_NAME }, bindingEnableId)
         })
 
         this.ws.on("message", (data) => {
@@ -105,6 +180,9 @@ export class ScreencastManager {
           } else if (message.id === runtimeEnableId) {
             runtimeEnabled = true
             checkReady()
+          } else if (message.id === bindingEnableId) {
+            const errorMessage = typeof message.error?.message === "string" ? message.error.message.toLowerCase() : ""
+            this.bindingAvailable = !message.error || errorMessage.includes("already")
           }
           this.handleMessage(message)
         })
@@ -158,6 +236,22 @@ export class ScreencastManager {
     // if (message.method && (message.method.startsWith("Page.") || message.method.startsWith("Network."))) {
     //   this.logFn(`[CDP] Received CDP event: ${message.method}`)
     // }
+
+    if (message.method === "Runtime.bindingCalled" && message.params) {
+      const params = message.params as { name?: unknown; payload?: unknown }
+      if (params.name === DEV3000_CDP_BINDING_NAME && typeof params.payload === "string") {
+        const telemetry = parseDev3000LayoutShiftPayload(params.payload)
+        if (telemetry) {
+          if (telemetry.viewport) {
+            this.viewportInfo = telemetry.viewport
+          }
+          this.onLayoutShift(telemetry.shift)
+        } else if (this.debug) {
+          this.logFn("[CDP] Ignoring malformed layout-shift telemetry payload")
+        }
+      }
+      return
+    }
 
     // Navigation started - check URL before capturing
     // Page.frameStartedLoading fires at the start of navigation
@@ -425,10 +519,26 @@ export class ScreencastManager {
    * Install PerformanceObserver for layout shifts (passive, no reload needed)
    */
   private installCLSObserver(): void {
+    const bindingNameLiteral = JSON.stringify(DEV3000_CDP_BINDING_NAME)
     const observerScript = `
       (function() {
         // Reset layout shifts array for new navigation
         window.__dev3000_layout_shifts__ = [];
+
+        // Prefer an event-driven CDP binding so layout shifts cross the browser
+        // boundary immediately instead of being sampled every 500ms.
+        const emitTelemetry = (value) => {
+          const binding = window[${bindingNameLiteral}];
+          if (typeof binding === 'function') {
+            try {
+              binding(JSON.stringify(value));
+              return true;
+            } catch (_) {
+              // Fall through to the compatibility queue below.
+            }
+          }
+          return false;
+        };
 
         // Update viewport info for current navigation
         window.__dev3000_viewport__ = {
@@ -490,11 +600,18 @@ export class ScreencastManager {
                   };
                 }) : [];
 
-                window.__dev3000_layout_shifts__.push({
+                const shift = {
                   score: entry.value,
                   timestamp: entry.startTime,
                   sources: sources
-                });
+                };
+                if (!emitTelemetry({
+                  kind: 'layout-shift',
+                  shift,
+                  viewport: window.__dev3000_viewport__
+                })) {
+                  window.__dev3000_layout_shifts__.push(shift);
+                }
               }
             }
           });
@@ -511,16 +628,44 @@ export class ScreencastManager {
     const evalId = this.messageId++
     this.send("Runtime.evaluate", { expression: observerScript, returnByValue: false }, evalId)
 
-    // Set up periodic polling to retrieve layout shift data
-    this.pollLayoutShifts()
+    // Set up periodic polling only for CDP implementations without bindings.
+    if (!this.bindingAvailable) {
+      this.pollLayoutShifts()
+    }
     // this.logFn("Installed CLS observer")
+  }
+
+  private onLayoutShift(shift: { score: number; timestamp: number; sources?: LayoutShiftSource[] }): void {
+    if (!this.isCapturing) return
+
+    this.layoutShifts.push(shift)
+    const element = shift.sources?.[0]?.node || "unidentified"
+    const position = shift.sources?.[0]?.position
+
+    // Only log verbose CDP diagnostics when debug mode is enabled
+    if (!this.debug) return
+
+    // Log with context about whether we can verify this shift
+    if (!shift.sources?.[0] || element === "unidentified" || position === null || position === undefined) {
+      this.logFn(
+        `[CDP] Unverified shift detected (score: ${shift.score.toFixed(4)}, time: ${shift.timestamp.toFixed(0)}ms) - element could not be identified, likely fixed overlay noise`
+      )
+    } else if (position === "fixed" || position === "absolute") {
+      this.logFn(
+        `[CDP] Fixed/absolute element shift detected (${element}, position: ${position}, score: ${shift.score.toFixed(4)}) - will be filtered as overlay noise`
+      )
+    } else {
+      this.logFn(
+        `[CDP] Layout shift detected (element: ${element}, position: ${position}, score: ${shift.score.toFixed(4)}, time: ${shift.timestamp.toFixed(0)}ms)`
+      )
+    }
   }
 
   /**
    * Poll for layout shift data from the injected observer
    */
   private pollLayoutShifts(): void {
-    if (!this.isCapturing) return
+    if (!this.isCapturing || this.bindingAvailable) return
 
     const pollId = this.messageId++
     const viewportId = this.messageId++
@@ -558,28 +703,8 @@ export class ScreencastManager {
         if (shifts.length > this.layoutShifts.length) {
           // New shifts detected
           const newShifts = shifts.slice(this.layoutShifts.length)
-          this.layoutShifts.push(...newShifts)
           newShifts.forEach((shift) => {
-            const element = shift.sources?.[0]?.node || "unidentified"
-            const position = shift.sources?.[0]?.position
-
-            // Only log verbose CDP diagnostics when debug mode is enabled
-            if (this.debug) {
-              // Log with context about whether we can verify this shift
-              if (!shift.sources?.[0] || element === "unidentified" || position === null || position === undefined) {
-                this.logFn(
-                  `[CDP] Unverified shift detected (score: ${shift.score.toFixed(4)}, time: ${shift.timestamp.toFixed(0)}ms) - element could not be identified, likely fixed overlay noise`
-                )
-              } else if (position === "fixed" || position === "absolute") {
-                this.logFn(
-                  `[CDP] Fixed/absolute element shift detected (${element}, position: ${position}, score: ${shift.score.toFixed(4)}) - will be filtered as overlay noise`
-                )
-              } else {
-                this.logFn(
-                  `[CDP] Layout shift detected (element: ${element}, position: ${position}, score: ${shift.score.toFixed(4)}, time: ${shift.timestamp.toFixed(0)}ms)`
-                )
-              }
-            }
+            this.onLayoutShift(shift)
           })
         }
       }

--- a/src/utils/browser-command-argv.test.ts
+++ b/src/utils/browser-command-argv.test.ts
@@ -4,7 +4,8 @@ import {
   getBrowserCommandInvocation,
   hasAgentBrowserOption,
   isAgentBrowserOpenCommand,
-  parseAgentBrowserInvocationArgs
+  parseAgentBrowserInvocationArgs,
+  withD3kSessionCdp
 } from "./browser-command-argv.js"
 
 describe("getBrowserCommandInvocation", () => {
@@ -85,5 +86,31 @@ describe("agent-browser invocation parsing", () => {
   it("detects options passed with separate or equals values", () => {
     expect(hasAgentBrowserOption(["--cdp", "9222", "open", "http://localhost:3000"], "--cdp")).toBe(true)
     expect(hasAgentBrowserOption(["--profile=/tmp/profile", "open", "http://localhost:3000"], "--profile")).toBe(true)
+  })
+
+  it("passes the active d3k CDP endpoint without a redundant connect process", () => {
+    expect(
+      withD3kSessionCdp(["snapshot", "-i"], {
+        sessionCdpPort: "9222",
+        hasExplicitCdp: false,
+        hasProfile: false
+      })
+    ).toEqual(["--cdp", "9222", "snapshot", "-i"])
+
+    expect(
+      withD3kSessionCdp(["--cdp", "9223", "snapshot"], {
+        sessionCdpPort: "9222",
+        hasExplicitCdp: true,
+        hasProfile: false
+      })
+    ).toEqual(["--cdp", "9223", "snapshot"])
+
+    expect(
+      withD3kSessionCdp(["close"], {
+        sessionCdpPort: "9222",
+        hasExplicitCdp: false,
+        hasProfile: false
+      })
+    ).toEqual(["close"])
   })
 })

--- a/src/utils/browser-command-argv.ts
+++ b/src/utils/browser-command-argv.ts
@@ -175,6 +175,24 @@ export function hasAgentBrowserOption(args: string[], option: string): boolean {
   return args.some((arg) => arg === option || arg.startsWith(`${option}=`))
 }
 
+export function withD3kSessionCdp(
+  args: string[],
+  options: { sessionCdpPort: string | null; hasExplicitCdp: boolean; hasProfile: boolean }
+): string[] {
+  const subcommand = getAgentBrowserSubcommand(args)
+  if (
+    !options.sessionCdpPort ||
+    options.hasExplicitCdp ||
+    options.hasProfile ||
+    subcommand === "connect" ||
+    subcommand === "close"
+  ) {
+    return args
+  }
+
+  return ["--cdp", options.sessionCdpPort, ...args]
+}
+
 export function hasD3kAgentBrowserWrapperFlag(args: string[]): boolean {
   return args.some((arg) => D3K_AGENT_BROWSER_WRAPPER_FLAGS.has(arg))
 }


### PR DESCRIPTION
## Summary

- Upgrade d3k's bundled `agent-browser` from `0.34.0` to `0.36.0`.
- Replace the 500 ms `Runtime.evaluate` telemetry loops with CDP
  `Runtime.addBinding`/`Runtime.bindingCalled`, retaining polling only as a
  compatibility fallback.
- Remove the extra `agent-browser connect` process d3k spawned before every
  browser command by passing the active CDP endpoint directly.
- Declare Ink's optional `react-devtools-core` peer so native binary builds are
  reproducible.

## Why

This keeps the high-fidelity path inside the runtime: interaction, React, and
layout-shift telemetry arrive as CDP events instead of repeatedly evaluating
page JavaScript, and browser commands use one native agent-browser process per
operation. The fork still retains a polling fallback for older pages/CDP
targets.

## Verification

- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `D3K_BUILD_TARGETS=darwin-arm64 bun run build:binaries` ✅
- Focused tests: 76 passed, 0 failed before the build-peer fix; full suite has
  the existing temp-home/session failures only.
